### PR TITLE
Support r2dbc

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Disable Property: `org.springframework.cloud.bindings.boot.db2.enable`
 | `spring.datasource.password` | `{secret/password}`
 | `spring.datasource.url` | `jdbc:db2://{secret/host}:{secret/port}/{secret/database}`
 | `spring.datasource.username` | `{secret/username}`
+| `spring.r2dbc.url` | `r2dbc:db2://{secret/host}:{secret/port}/{secret/database}`
+| `spring.r2dbc.password` | `{secret/password}`
+| `spring.r2dbc.username` | `{secret/username}`
 
 
 ### Elasticsearch
@@ -127,6 +130,9 @@ Disable Property: `org.springframework.cloud.bindings.boot.mysql.enable`
 | `spring.datasource.password` | `{secret/password}`
 | `spring.datasource.url` | `jdbc:mysql://{secret/host}:{secret/port}/{secret/database}`
 | `spring.datasource.username` | `{secret/username}`
+| `spring.r2dbc.url` | `r2dbc:mysql://{secret/host}:{secret/port}/{secret/database}`
+| `spring.r2dbc.password` | `{secret/password}`
+| `spring.r2dbc.username` | `{secret/username}`
 
 ### Neo4J
 Kind: `Neo4J`
@@ -148,6 +154,9 @@ Disable Property: `org.springframework.cloud.bindings.boot.oracle.enable`
 | `spring.datasource.password` | `{secret/password}`
 | `spring.datasource.url` | `jdbc:oracle://{secret/host}:{secret/port}/{secret/database}`
 | `spring.datasource.username` | `{secret/username}`
+| `spring.r2dbc.url` | `r2dbc:oracle://{secret/host}:{secret/port}/{secret/database}`
+| `spring.r2dbc.password` | `{secret/password}`
+| `spring.r2dbc.username` | `{secret/username}`
 
 ### PostgreSQL RDBMS
 Kind: `PostgreSQL`
@@ -159,6 +168,9 @@ Disable Property: `org.springframework.cloud.bindings.boot.postgresql.enable`
 | `spring.datasource.password` | `{secret/password}`
 | `spring.datasource.url` | `jdbc:postgres://{secret/host}:{secret/port}/{secret/database}`
 | `spring.datasource.username` | `{secret/username}`
+| `spring.r2dbc.url` | `r2dbc:postgres://{secret/host}:{secret/port}/{secret/database}`
+| `spring.r2dbc.password` | `{secret/password}`
+| `spring.r2dbc.username` | `{secret/username}`
 
 ### RabbitMQ RDBMS
 Kind: `RabbitMQ`
@@ -201,6 +213,9 @@ Disable Property: `org.springframework.cloud.bindings.boot.sqlserver.enable`
 | `spring.datasource.password` | `{secret/password}`
 | `spring.datasource.url` | `jdbc:sqlserver://{secret/host}:{secret/port}/{secret/database}`
 | `spring.datasource.username` | `{secret/username}`
+| `spring.r2dbc.url` | `r2dbc:sqlserver://{secret/host}:{secret/port}/{secret/database}`
+| `spring.r2dbc.password` | `{secret/password}`
+| `spring.r2dbc.username` | `{secret/username}`
 
 ### Wavefront
 

--- a/src/main/java/org/springframework/cloud/bindings/Binding.java
+++ b/src/main/java/org/springframework/cloud/bindings/Binding.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.cloud.bindings;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -141,6 +142,8 @@ public final class Binding {
     private Map<String, String> createFilePerEntryMap(Path path) {
         try {
             return Files.list(path)
+                    .filter(p -> !p.getFileName().toString().startsWith("."))
+                    .filter(p -> !new File(p.toString()).isDirectory())
                     .collect(Collectors.toMap(
                             p -> p.getFileName().toString(),
                             p -> {

--- a/src/main/java/org/springframework/cloud/bindings/boot/Db2BindingsPropertiesProcessor.java
+++ b/src/main/java/org/springframework/cloud/bindings/boot/Db2BindingsPropertiesProcessor.java
@@ -45,12 +45,19 @@ public final class Db2BindingsPropertiesProcessor implements BindingsPropertiesP
         bindings.filterBindings(KIND).forEach(binding -> {
             MapMapper map = new MapMapper(binding.getSecret(), properties);
 
+            //jdbc properties
             map.from("password").to("spring.datasource.password");
             map.from("host", "port", "database").to("spring.datasource.url",
                     (host, port, database) -> String.format("jdbc:db2://%s:%s/%s", host, port, database));
             map.from("username").to("spring.datasource.username");
 
             properties.put("spring.datasource.driver-class-name", "com.ibm.db2.jcc.DB2Driver");
+
+            //r2dbc properties
+            map.from("password").to("spring.r2dbc.password");
+            map.from("host", "port", "database").to("spring.r2dbc.url",
+                    (host, port, database) -> String.format("r2dbc:db2://%s:%s/%s", host, port, database));
+            map.from("username").to("spring.r2dbc.username");
         });
     }
 

--- a/src/main/java/org/springframework/cloud/bindings/boot/MySqlBindingsPropertiesProcessor.java
+++ b/src/main/java/org/springframework/cloud/bindings/boot/MySqlBindingsPropertiesProcessor.java
@@ -45,13 +45,11 @@ public final class MySqlBindingsPropertiesProcessor implements BindingsPropertie
         bindings.filterBindings(KIND).forEach(binding -> {
             MapMapper map = new MapMapper(binding.getSecret(), properties);
 
+            //jdbc properties
             map.from("password").to("spring.datasource.password");
             map.from("host", "port", "database").to("spring.datasource.url",
                     (host, port, database) -> String.format("jdbc:mysql://%s:%s/%s", host, port, database));
             map.from("username").to("spring.datasource.username");
-
-
-            Map<String, String> secret = binding.getSecret();
 
             try {
                 Class.forName("org.mariadb.jdbc.Driver", false, getClass().getClassLoader());
@@ -63,6 +61,12 @@ public final class MySqlBindingsPropertiesProcessor implements BindingsPropertie
                 } catch (ClassNotFoundException ignored) {
                 }
             }
+
+            //r2dbc properties
+            map.from("password").to("spring.r2dbc.password");
+            map.from("host", "port", "database").to("spring.r2dbc.url",
+                    (host, port, database) -> String.format("r2dbc:mysql://%s:%s/%s", host, port, database));
+            map.from("username").to("spring.r2dbc.username");
         });
     }
 

--- a/src/main/java/org/springframework/cloud/bindings/boot/OracleBindingsPropertiesProcessor.java
+++ b/src/main/java/org/springframework/cloud/bindings/boot/OracleBindingsPropertiesProcessor.java
@@ -45,12 +45,19 @@ public final class OracleBindingsPropertiesProcessor implements BindingsProperti
         bindings.filterBindings(KIND).forEach(binding -> {
             MapMapper map = new MapMapper(binding.getSecret(), properties);
 
+            //jdbc properties
             map.from("password").to("spring.datasource.password");
             map.from("host", "port", "database").to("spring.datasource.url",
                     (host, port, database) -> String.format("jdbc:oracle://%s:%s/%s", host, port, database));
             map.from("username").to("spring.datasource.username");
 
             properties.put("spring.datasource.driver-class-name", "oracle.jdbc.OracleDriver");
+
+            //r2dbc properties
+            map.from("password").to("spring.r2dbc.password");
+            map.from("host", "port", "database").to("spring.r2dbc.url",
+                    (host, port, database) -> String.format("r2dbc:oracle://%s:%s/%s", host, port, database));
+            map.from("username").to("spring.r2dbc.username");
         });
     }
 

--- a/src/main/java/org/springframework/cloud/bindings/boot/PostgreSqlBindingsPropertiesProcessor.java
+++ b/src/main/java/org/springframework/cloud/bindings/boot/PostgreSqlBindingsPropertiesProcessor.java
@@ -45,12 +45,19 @@ public final class PostgreSqlBindingsPropertiesProcessor implements BindingsProp
         bindings.filterBindings(KIND).forEach(binding -> {
             MapMapper map = new MapMapper(binding.getSecret(), properties);
 
+            //jdbc properties
             map.from("password").to("spring.datasource.password");
             map.from("host", "port", "database").to("spring.datasource.url",
                     (host, port, database) -> String.format("jdbc:postgres://%s:%s/%s", host, port, database));
             map.from("username").to("spring.datasource.username");
 
             properties.put("spring.datasource.driver-class-name", "org.postgresql.Driver");
+
+            //r2dbc properties
+            map.from("password").to("spring.r2dbc.password");
+            map.from("host", "port", "database").to("spring.r2dbc.url",
+                    (host, port, database) -> String.format("r2dbc:postgres://%s:%s/%s", host, port, database));
+            map.from("username").to("spring.r2dbc.username");
         });
     }
 

--- a/src/main/java/org/springframework/cloud/bindings/boot/SqlServerBindingsPropertiesProcessor.java
+++ b/src/main/java/org/springframework/cloud/bindings/boot/SqlServerBindingsPropertiesProcessor.java
@@ -45,12 +45,19 @@ public final class SqlServerBindingsPropertiesProcessor implements BindingsPrope
         bindings.filterBindings(KIND).forEach(binding -> {
             MapMapper map = new MapMapper(binding.getSecret(), properties);
 
+            //jdbc properties
             map.from("password").to("spring.datasource.password");
             map.from("host", "port", "database").to("spring.datasource.url",
                     (host, port, database) -> String.format("jdbc:sqlserver://%s:%s/%s", host, port, database));
             map.from("username").to("spring.datasource.username");
 
             properties.put("spring.datasource.driver-class-name", "com.microsoft.sqlserver.jdbc.SQLServerDriver");
+
+            //r2dbc properties
+            map.from("password").to("spring.r2dbc.password");
+            map.from("host", "port", "database").to("spring.r2dbc.url",
+                    (host, port, database) -> String.format("r2dbc:sqlserver://%s:%s/%s", host, port, database));
+            map.from("username").to("spring.r2dbc.username");
         });
     }
 

--- a/src/test/java/org/springframework/cloud/bindings/BindingTest.java
+++ b/src/test/java/org/springframework/cloud/bindings/BindingTest.java
@@ -39,4 +39,17 @@ final class BindingTest {
                 .isEqualTo(Paths.get("src/test/resources/test-name-1/secret/test-key"));
     }
 
+    @Test
+    @DisplayName("populates k8s style content from filesystem")
+    void testK8s() {
+        //When bindings are provided as a k8s configmap secret pairs data files will be symlinks to hidden directories
+        Binding binding = new Binding(Paths.get("src/test/resources/test-k8s"));
+
+        assertThat(binding.getKind()).isEqualTo("test-kind-1");
+        assertThat(binding.getProvider()).isEqualTo("test-provider-1");
+        assertThat(binding.getMetadataFilePath("test-key"))
+                .isEqualTo(Paths.get("src/test/resources/test-k8s/metadata/test-key"));
+        assertThat(binding.getSecretFilePath("test-key"))
+                .isEqualTo(Paths.get("src/test/resources/test-k8s/secret/test-key"));
+    }
 }

--- a/src/test/java/org/springframework/cloud/bindings/BindingsTests.java
+++ b/src/test/java/org/springframework/cloud/bindings/BindingsTests.java
@@ -65,7 +65,7 @@ final class BindingsTests {
             String path = "src/test/resources";
             Bindings b = new Bindings(path);
 
-            assertThat(b.getBindings()).hasSize(2);
+            assertThat(b.getBindings()).hasSize(3);
         }
 
     }
@@ -102,5 +102,4 @@ final class BindingsTests {
         }
 
     }
-
 }

--- a/src/test/java/org/springframework/cloud/bindings/boot/BindingSpecificEnvironmentPostProcessorTest.java
+++ b/src/test/java/org/springframework/cloud/bindings/boot/BindingSpecificEnvironmentPostProcessorTest.java
@@ -98,7 +98,7 @@ final class BindingSpecificEnvironmentPostProcessorTest {
     @Test
     @DisplayName("included implementations are registered")
     void includedImplementations() {
-        assertThat(new BindingSpecificEnvironmentPostProcessor().processors).hasSize(14);
+        assertThat(new BindingSpecificEnvironmentPostProcessor().processors).hasSize(15);
     }
 
 }

--- a/src/test/java/org/springframework/cloud/bindings/boot/Db2BindingsPropertiesProcessorTest.java
+++ b/src/test/java/org/springframework/cloud/bindings/boot/Db2BindingsPropertiesProcessorTest.java
@@ -50,8 +50,8 @@ final class Db2BindingsPropertiesProcessorTest {
     private final HashMap<String, Object> properties = new HashMap<>();
 
     @Test
-    @DisplayName("contributes properties")
-    void test() {
+    @DisplayName("contributes jdbc properties")
+    void testJdbc() {
         new Db2BindingsPropertiesProcessor().process(environment, bindings, properties);
         assertThat(properties)
                 .containsEntry("spring.datasource.driver-class-name", "com.ibm.db2.jcc.DB2Driver")
@@ -59,6 +59,15 @@ final class Db2BindingsPropertiesProcessorTest {
                 .containsEntry("spring.datasource.url", "jdbc:db2://test-host:test-port/test-database")
                 .containsEntry("spring.datasource.username", "test-username");
     }
+
+    @Test
+    @DisplayName("contributes r2dbc properties")
+    void testR2dbc() {
+        new Db2BindingsPropertiesProcessor().process(environment, bindings, properties);
+        assertThat(properties)
+                .containsEntry("spring.r2dbc.password", "test-password")
+                .containsEntry("spring.r2dbc.url", "r2dbc:db2://test-host:test-port/test-database")
+                .containsEntry("spring.r2dbc.username", "test-username");    }
 
     @Test
     @DisplayName("can be disabled")

--- a/src/test/java/org/springframework/cloud/bindings/boot/MySqlBindingsPropertiesProcessorTest.java
+++ b/src/test/java/org/springframework/cloud/bindings/boot/MySqlBindingsPropertiesProcessorTest.java
@@ -50,14 +50,24 @@ final class MySqlBindingsPropertiesProcessorTest {
     private final HashMap<String, Object> properties = new HashMap<>();
 
     @Test
-    @DisplayName("contributes properties")
-    void test() {
+    @DisplayName("contributes jdbc properties")
+    void testJdbc() {
         new MySqlBindingsPropertiesProcessor().process(environment, bindings, properties);
         assertThat(properties)
                 .containsEntry("spring.datasource.driver-class-name", "org.mariadb.jdbc.Driver")
                 .containsEntry("spring.datasource.password", "test-password")
                 .containsEntry("spring.datasource.url", "jdbc:mysql://test-host:test-port/test-database")
                 .containsEntry("spring.datasource.username", "test-username");
+    }
+
+    @Test
+    @DisplayName("contributes r2dbc properties")
+    void testR2dbc() {
+        new MySqlBindingsPropertiesProcessor().process(environment, bindings, properties);
+        assertThat(properties)
+                .containsEntry("spring.r2dbc.password", "test-password")
+                .containsEntry("spring.r2dbc.url", "r2dbc:mysql://test-host:test-port/test-database")
+                .containsEntry("spring.r2dbc.username", "test-username");
     }
 
     @Test

--- a/src/test/java/org/springframework/cloud/bindings/boot/OracleBindingsPropertiesProcessorTest.java
+++ b/src/test/java/org/springframework/cloud/bindings/boot/OracleBindingsPropertiesProcessorTest.java
@@ -50,14 +50,24 @@ final class OracleBindingsPropertiesProcessorTest {
     private final HashMap<String, Object> properties = new HashMap<>();
 
     @Test
-    @DisplayName("contributes properties")
-    void test() {
+    @DisplayName("contributes jdbc properties")
+    void testJdbc() {
         new OracleBindingsPropertiesProcessor().process(environment, bindings, properties);
         assertThat(properties)
                 .containsEntry("spring.datasource.driver-class-name", "oracle.jdbc.OracleDriver")
                 .containsEntry("spring.datasource.password", "test-password")
                 .containsEntry("spring.datasource.url", "jdbc:oracle://test-host:test-port/test-database")
                 .containsEntry("spring.datasource.username", "test-username");
+    }
+
+    @Test
+    @DisplayName("contributes r2dbc properties")
+    void testR2dbc() {
+        new OracleBindingsPropertiesProcessor().process(environment, bindings, properties);
+        assertThat(properties)
+                .containsEntry("spring.r2dbc.password", "test-password")
+                .containsEntry("spring.r2dbc.url", "r2dbc:oracle://test-host:test-port/test-database")
+                .containsEntry("spring.r2dbc.username", "test-username");
     }
 
     @Test

--- a/src/test/java/org/springframework/cloud/bindings/boot/PostgreSqlBindingsPropertiesProcessorTest.java
+++ b/src/test/java/org/springframework/cloud/bindings/boot/PostgreSqlBindingsPropertiesProcessorTest.java
@@ -50,14 +50,24 @@ final class PostgreSqlBindingsPropertiesProcessorTest {
     private final HashMap<String, Object> properties = new HashMap<>();
 
     @Test
-    @DisplayName("contributes properties")
-    void test() {
+    @DisplayName("contributes jdbc properties")
+    void testJdbc() {
         new PostgreSqlBindingsPropertiesProcessor().process(environment, bindings, properties);
         assertThat(properties)
                 .containsEntry("spring.datasource.driver-class-name", "org.postgresql.Driver")
                 .containsEntry("spring.datasource.password", "test-password")
                 .containsEntry("spring.datasource.url", "jdbc:postgres://test-host:test-port/test-database")
                 .containsEntry("spring.datasource.username", "test-username");
+    }
+
+    @Test
+    @DisplayName("contributes r2dbc properties")
+    void testR2dbc() {
+        new PostgreSqlBindingsPropertiesProcessor().process(environment, bindings, properties);
+        assertThat(properties)
+                .containsEntry("spring.r2dbc.password", "test-password")
+                .containsEntry("spring.r2dbc.url", "r2dbc:postgres://test-host:test-port/test-database")
+                .containsEntry("spring.r2dbc.username", "test-username");
     }
 
     @Test

--- a/src/test/java/org/springframework/cloud/bindings/boot/SqlServerBindingsPropertiesProcessorTest.java
+++ b/src/test/java/org/springframework/cloud/bindings/boot/SqlServerBindingsPropertiesProcessorTest.java
@@ -50,14 +50,24 @@ final class SqlServerBindingsPropertiesProcessorTest {
     private final HashMap<String, Object> properties = new HashMap<>();
 
     @Test
-    @DisplayName("contributes properties")
-    void test() {
+    @DisplayName("contributes jdbc properties")
+    void testJdbc() {
         new SqlServerBindingsPropertiesProcessor().process(environment, bindings, properties);
         assertThat(properties)
                 .containsEntry("spring.datasource.driver-class-name", "com.microsoft.sqlserver.jdbc.SQLServerDriver")
                 .containsEntry("spring.datasource.password", "test-password")
                 .containsEntry("spring.datasource.url", "jdbc:sqlserver://test-host:test-port/test-database")
                 .containsEntry("spring.datasource.username", "test-username");
+    }
+
+    @Test
+    @DisplayName("contributes r2dbc properties")
+    void testR2dbc() {
+        new SqlServerBindingsPropertiesProcessor().process(environment, bindings, properties);
+        assertThat(properties)
+                .containsEntry("spring.r2dbc.password", "test-password")
+                .containsEntry("spring.r2dbc.url", "r2dbc:sqlserver://test-host:test-port/test-database")
+                .containsEntry("spring.r2dbc.username", "test-username");
     }
 
     @Test

--- a/src/test/resources/test-k8s/metadata/.hidden-data
+++ b/src/test/resources/test-k8s/metadata/.hidden-data
@@ -1,0 +1,1 @@
+.hidden-data-1

--- a/src/test/resources/test-k8s/metadata/.hidden-data-1/kind
+++ b/src/test/resources/test-k8s/metadata/.hidden-data-1/kind
@@ -1,0 +1,1 @@
+test-kind-1

--- a/src/test/resources/test-k8s/metadata/.hidden-data-1/provider
+++ b/src/test/resources/test-k8s/metadata/.hidden-data-1/provider
@@ -1,0 +1,1 @@
+test-provider-1

--- a/src/test/resources/test-k8s/metadata/kind
+++ b/src/test/resources/test-k8s/metadata/kind
@@ -1,0 +1,1 @@
+.hidden-data/kind

--- a/src/test/resources/test-k8s/metadata/provider
+++ b/src/test/resources/test-k8s/metadata/provider
@@ -1,0 +1,1 @@
+.hidden-data/provider

--- a/src/test/resources/test-k8s/secret/.hidden-data
+++ b/src/test/resources/test-k8s/secret/.hidden-data
@@ -1,0 +1,1 @@
+.hidden-data-1

--- a/src/test/resources/test-k8s/secret/.hidden-data-1/test-key
+++ b/src/test/resources/test-k8s/secret/.hidden-data-1/test-key
@@ -1,0 +1,1 @@
+test-value

--- a/src/test/resources/test-k8s/secret/test-key
+++ b/src/test/resources/test-k8s/secret/test-key
@@ -1,0 +1,1 @@
+.hidden-data/test-key


### PR DESCRIPTION
Adds r2dbc properties for mysql, postgres, sqlserver, oracle, and db2
bindings. This allow bindings to be used with reactive drivers.

Resolves #13 