### PR TITLE
Fixes Spring Boot property mapping for MongoDB

### DIFF
--- a/src/main/java/org/springframework/cloud/bindings/boot/MongoDbBindingsPropertiesProcessor.java
+++ b/src/main/java/org/springframework/cloud/bindings/boot/MongoDbBindingsPropertiesProcessor.java
@@ -43,14 +43,14 @@ public final class MongoDbBindingsPropertiesProcessor implements BindingsPropert
         bindings.filterBindings(TYPE).forEach(binding -> {
             MapMapper map = new MapMapper(binding.getSecret(), properties);
 
-            map.from("authentication-database").to("spring.mongodb.authentication-database");
-            map.from("database").to("spring.mongodb.database");
-            map.from("grid-fs-database").to("spring.mongodb.grid-fs-database");
-            map.from("host").to("spring.mongodb.host");
-            map.from("password").to("spring.mongodb.password");
-            map.from("port").to("spring.mongodb.port");
-            map.from("uri").to("spring.mongodb.uri");
-            map.from("username").to("spring.mongodb.username");
+            map.from("authentication-database").to("spring.data.mongodb.authentication-database");
+            map.from("database").to("spring.data.mongodb.database");
+            map.from("grid-fs-database").to("spring.data.mongodb.gridfs.database");
+            map.from("host").to("spring.data.mongodb.host");
+            map.from("password").to("spring.data.mongodb.password");
+            map.from("port").to("spring.data.mongodb.port");
+            map.from("uri").to("spring.data.mongodb.uri");
+            map.from("username").to("spring.data.mongodb.username");
         });
     }
 

--- a/src/test/java/org/springframework/cloud/bindings/boot/MongoDbBindingsPropertiesProcessorTest.java
+++ b/src/test/java/org/springframework/cloud/bindings/boot/MongoDbBindingsPropertiesProcessorTest.java
@@ -56,14 +56,14 @@ final class MongoDbBindingsPropertiesProcessorTest {
     void test() {
         new MongoDbBindingsPropertiesProcessor().process(environment, bindings, properties);
         assertThat(properties)
-                .containsEntry("spring.mongodb.authentication-database", "test-authentication-database")
-                .containsEntry("spring.mongodb.database", "test-database")
-                .containsEntry("spring.mongodb.grid-fs-database", "test-grid-fs-database")
-                .containsEntry("spring.mongodb.host", "test-host")
-                .containsEntry("spring.mongodb.password", "test-password")
-                .containsEntry("spring.mongodb.port", "test-port")
-                .containsEntry("spring.mongodb.uri", "test-uri")
-                .containsEntry("spring.mongodb.username", "test-username");
+                .containsEntry("spring.data.mongodb.authentication-database", "test-authentication-database")
+                .containsEntry("spring.data.mongodb.database", "test-database")
+                .containsEntry("spring.data.mongodb.gridfs.database", "test-grid-fs-database")
+                .containsEntry("spring.data.mongodb.host", "test-host")
+                .containsEntry("spring.data.mongodb.password", "test-password")
+                .containsEntry("spring.data.mongodb.port", "test-port")
+                .containsEntry("spring.data.mongodb.uri", "test-uri")
+                .containsEntry("spring.data.mongodb.username", "test-username");
     }
 
     @Test


### PR DESCRIPTION
Spring Boot properties for MongoDB auto-configuration should have the
prefix `spring.data.mongodb` instead of `spring.mongodb`.

Signed-off-by: Scott Frederick <sfrederick@vmware.com>