### PR TITLE
Allow users to explicitly specify jdbc or r2dbc URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ Disable Property: `org.springframework.cloud.bindings.boot.db2.enable`
 | -------- | ------------------
 | `spring.datasource.driver-class-name` | `com.ibm.db2.jcc.DB2Driver`
 | `spring.datasource.password` | `{password}`
-| `spring.datasource.url` | `jdbc:db2://{host}:{port}/{database}`
+| `spring.datasource.url` | `{jdbc-url}` or `jdbc:db2://{host}:{port}/{database}`
 | `spring.datasource.username` | `{username}`
-| `spring.r2dbc.url` | `r2dbc:db2://{host}:{port}/{database}`
+| `spring.r2dbc.url` | `{r2dbc-url}` or `r2dbc:db2://{host}:{port}/{database}`
 | `spring.r2dbc.password` | `{password}`
 | `spring.r2dbc.username` | `{username}`
 
@@ -141,9 +141,9 @@ Disable Property: `org.springframework.cloud.bindings.boot.mysql.enable`
 | -------- | ------------------
 | `spring.datasource.driver-class-name` | `org.mariadb.jdbc.Driver` or `com.mysql.cj.jdbc.Driver` depending on classpath
 | `spring.datasource.password` | `{password}`
-| `spring.datasource.url` | `jdbc:mysql://{host}:{port}/{database}`
+| `spring.datasource.url` | `{jdbc-url}` or `jdbc:mysql://{host}:{port}/{database}`
 | `spring.datasource.username` | `{username}`
-| `spring.r2dbc.url` | `r2dbc:mysql://{host}:{port}/{database}`
+| `spring.r2dbc.url` | `{r2dbc-url}` or `r2dbc:mysql://{host}:{port}/{database}`
 | `spring.r2dbc.password` | `{password}`
 | `spring.r2dbc.username` | `{username}`
 
@@ -165,9 +165,9 @@ Disable Property: `org.springframework.cloud.bindings.boot.oracle.enable`
 | -------- | ------------------
 | `spring.datasource.driver-class-name` | `oracle.jdbc.OracleDriver`
 | `spring.datasource.password` | `{password}`
-| `spring.datasource.url` | `jdbc:oracle://{host}:{port}/{database}`
+| `spring.datasource.url` | `{jdbc-url}` or `jdbc:oracle://{host}:{port}/{database}`
 | `spring.datasource.username` | `{username}`
-| `spring.r2dbc.url` | `r2dbc:oracle://{host}:{port}/{database}`
+| `spring.r2dbc.url` | `{r2dbc-url}` or `r2dbc:oracle://{host}:{port}/{database}`
 | `spring.r2dbc.password` | `{password}`
 | `spring.r2dbc.username` | `{username}`
 
@@ -179,9 +179,9 @@ Disable Property: `org.springframework.cloud.bindings.boot.postgresql.enable`
 | -------- | ------------------
 | `spring.datasource.driver-class-name` | `org.postgresql.Driver`
 | `spring.datasource.password` | `{password}`
-| `spring.datasource.url` | `jdbc:postgres://{host}:{port}/{database}`
+| `spring.datasource.url` | `{jdbc-url}` or `jdbc:postgres://{host}:{port}/{database}`
 | `spring.datasource.username` | `{username}`
-| `spring.r2dbc.url` | `r2dbc:postgres://{host}:{port}/{database}`
+| `spring.r2dbc.url` | `{r2dbc-url}` or `r2dbc:postgres://{host}:{port}/{database}`
 | `spring.r2dbc.password` | `{password}`
 | `spring.r2dbc.username` | `{username}`
 
@@ -265,7 +265,7 @@ Disable Property: `org.springframework.cloud.bindings.boot.sqlserver.enable`
 | `spring.datasource.password` | `{password}`
 | `spring.datasource.url` | `jdbc:sqlserver://{host}:{port}/{database}`
 | `spring.datasource.username` | `{username}`
-| `spring.r2dbc.url` | `r2dbc:sqlserver://{host}:{port}/{database}`
+| `spring.r2dbc.url` | `{r2dbc-url}` or `r2dbc:sqlserver://{host}:{port}/{database}`
 | `spring.r2dbc.password` | `{password}`
 | `spring.r2dbc.username` | `{username}`
 

--- a/src/main/java/org/springframework/cloud/bindings/boot/BindingSpecificEnvironmentPostProcessor.java
+++ b/src/main/java/org/springframework/cloud/bindings/boot/BindingSpecificEnvironmentPostProcessor.java
@@ -104,6 +104,7 @@ public final class BindingSpecificEnvironmentPostProcessor implements Applicatio
         }
 
         LOG.info("Creating binding-specific PropertySource from Kubernetes Service Bindings");
+        LOG.info("DEV VERSION");
         contributePropertySource(BINDING_SPECIFIC_PROPERTY_SOURCE_NAME, properties, environment);
     }
 

--- a/src/main/java/org/springframework/cloud/bindings/boot/Db2BindingsPropertiesProcessor.java
+++ b/src/main/java/org/springframework/cloud/bindings/boot/Db2BindingsPropertiesProcessor.java
@@ -46,18 +46,24 @@ public final class Db2BindingsPropertiesProcessor implements BindingsPropertiesP
             MapMapper map = new MapMapper(binding.getSecret(), properties);
 
             //jdbc properties
+            map.from("username").to("spring.datasource.username");
             map.from("password").to("spring.datasource.password");
             map.from("host", "port", "database").to("spring.datasource.url",
                     (host, port, database) -> String.format("jdbc:db2://%s:%s/%s", host, port, database));
-            map.from("username").to("spring.datasource.username");
+
+            // jdbcURL takes precedence
+            map.from("jdbc-url").to("spring.datasource.url");
 
             properties.put("spring.datasource.driver-class-name", "com.ibm.db2.jcc.DB2Driver");
 
             //r2dbc properties
+            map.from("username").to("spring.r2dbc.username");
             map.from("password").to("spring.r2dbc.password");
             map.from("host", "port", "database").to("spring.r2dbc.url",
                     (host, port, database) -> String.format("r2dbc:db2://%s:%s/%s", host, port, database));
-            map.from("username").to("spring.r2dbc.username");
+
+            // r2dbcURL takes precedence
+            map.from("r2dbc-url").to("spring.r2dbc.url");
         });
     }
 

--- a/src/main/java/org/springframework/cloud/bindings/boot/MySqlBindingsPropertiesProcessor.java
+++ b/src/main/java/org/springframework/cloud/bindings/boot/MySqlBindingsPropertiesProcessor.java
@@ -46,10 +46,13 @@ public final class MySqlBindingsPropertiesProcessor implements BindingsPropertie
             MapMapper map = new MapMapper(binding.getSecret(), properties);
 
             //jdbc properties
+            map.from("username").to("spring.datasource.username");
             map.from("password").to("spring.datasource.password");
             map.from("host", "port", "database").to("spring.datasource.url",
                     (host, port, database) -> String.format("jdbc:mysql://%s:%s/%s", host, port, database));
-            map.from("username").to("spring.datasource.username");
+
+            // jdbcURL takes precedence
+            map.from("jdbc-url").to("spring.datasource.url");
 
             try {
                 Class.forName("org.mariadb.jdbc.Driver", false, getClass().getClassLoader());
@@ -67,6 +70,9 @@ public final class MySqlBindingsPropertiesProcessor implements BindingsPropertie
             map.from("host", "port", "database").to("spring.r2dbc.url",
                     (host, port, database) -> String.format("r2dbc:mysql://%s:%s/%s", host, port, database));
             map.from("username").to("spring.r2dbc.username");
+
+            // r2dbcURL takes precedence
+            map.from("r2dbc-url").to("spring.r2dbc.url");
         });
     }
 

--- a/src/main/java/org/springframework/cloud/bindings/boot/OracleBindingsPropertiesProcessor.java
+++ b/src/main/java/org/springframework/cloud/bindings/boot/OracleBindingsPropertiesProcessor.java
@@ -46,18 +46,24 @@ public final class OracleBindingsPropertiesProcessor implements BindingsProperti
             MapMapper map = new MapMapper(binding.getSecret(), properties);
 
             //jdbc properties
+            map.from("username").to("spring.datasource.username");
             map.from("password").to("spring.datasource.password");
             map.from("host", "port", "database").to("spring.datasource.url",
                     (host, port, database) -> String.format("jdbc:oracle://%s:%s/%s", host, port, database));
-            map.from("username").to("spring.datasource.username");
+
+            // jdbcURL takes precedence
+            map.from("jdbc-url").to("spring.datasource.url");
 
             properties.put("spring.datasource.driver-class-name", "oracle.jdbc.OracleDriver");
 
             //r2dbc properties
+            map.from("username").to("spring.r2dbc.username");
             map.from("password").to("spring.r2dbc.password");
             map.from("host", "port", "database").to("spring.r2dbc.url",
                     (host, port, database) -> String.format("r2dbc:oracle://%s:%s/%s", host, port, database));
-            map.from("username").to("spring.r2dbc.username");
+
+            // r2dbcURL takes precedence
+            map.from("r2dbc-url").to("spring.r2dbc.url");
         });
     }
 

--- a/src/main/java/org/springframework/cloud/bindings/boot/PostgreSqlBindingsPropertiesProcessor.java
+++ b/src/main/java/org/springframework/cloud/bindings/boot/PostgreSqlBindingsPropertiesProcessor.java
@@ -51,6 +51,9 @@ public final class PostgreSqlBindingsPropertiesProcessor implements BindingsProp
                     (host, port, database) -> String.format("jdbc:postgresql://%s:%s/%s", host, port, database));
             map.from("username").to("spring.datasource.username");
 
+            // jdbcURL takes precedence
+            map.from("jdbc-url").to("spring.datasource.url");
+
             properties.put("spring.datasource.driver-class-name", "org.postgresql.Driver");
 
             //r2dbc properties
@@ -58,6 +61,9 @@ public final class PostgreSqlBindingsPropertiesProcessor implements BindingsProp
             map.from("host", "port", "database").to("spring.r2dbc.url",
                     (host, port, database) -> String.format("r2dbc:postgresql://%s:%s/%s", host, port, database));
             map.from("username").to("spring.r2dbc.username");
+
+            // r2dbcURL takes precedence
+            map.from("r2dbc-url").to("spring.r2dbc.url");
         });
     }
 

--- a/src/main/java/org/springframework/cloud/bindings/boot/SqlServerBindingsPropertiesProcessor.java
+++ b/src/main/java/org/springframework/cloud/bindings/boot/SqlServerBindingsPropertiesProcessor.java
@@ -51,6 +51,9 @@ public final class SqlServerBindingsPropertiesProcessor implements BindingsPrope
                     (host, port, database) -> String.format("jdbc:sqlserver://%s:%s/%s", host, port, database));
             map.from("username").to("spring.datasource.username");
 
+            // jdbcURL takes precedence
+            map.from("jdbc-url").to("spring.datasource.url");
+
             properties.put("spring.datasource.driver-class-name", "com.microsoft.sqlserver.jdbc.SQLServerDriver");
 
             //r2dbc properties
@@ -58,6 +61,9 @@ public final class SqlServerBindingsPropertiesProcessor implements BindingsPrope
             map.from("host", "port", "database").to("spring.r2dbc.url",
                     (host, port, database) -> String.format("r2dbc:sqlserver://%s:%s/%s", host, port, database));
             map.from("username").to("spring.r2dbc.username");
+
+            // r2dbcURL takes precedence
+            map.from("r2dbc-url").to("spring.r2dbc.url");
         });
     }
 

--- a/src/test/java/org/springframework/cloud/bindings/boot/MySqlBindingsPropertiesProcessorTest.java
+++ b/src/test/java/org/springframework/cloud/bindings/boot/MySqlBindingsPropertiesProcessorTest.java
@@ -32,25 +32,24 @@ import static org.springframework.cloud.bindings.boot.MySqlBindingsPropertiesPro
 @DisplayName("MySQL BindingsPropertiesProcessor")
 final class MySqlBindingsPropertiesProcessorTest {
 
-    private final Bindings bindings = new Bindings(
-            new Binding("test-name", Paths.get("test-path"),
-                    new FluentMap()
-                            .withEntry(Binding.TYPE, TYPE)
-                            .withEntry("database", "test-database")
-                            .withEntry("host", "test-host")
-                            .withEntry("password", "test-password")
-                            .withEntry("port", "test-port")
-                            .withEntry("username", "test-username")
-            )
-    );
+    private final FluentMap secret = new FluentMap()
+            .withEntry(Binding.TYPE, TYPE)
+            .withEntry("database", "test-database")
+            .withEntry("host", "test-host")
+            .withEntry("password", "test-password")
+            .withEntry("port", "test-port")
+            .withEntry("username", "test-username");
 
     private final MockEnvironment environment = new MockEnvironment();
 
     private final HashMap<String, Object> properties = new HashMap<>();
 
     @Test
-    @DisplayName("contributes jdbc properties")
+    @DisplayName("composes jdbc url from host port and database")
     void testJdbc() {
+        Bindings bindings = new Bindings(
+                new Binding("test-name", Paths.get("test-path"), secret)
+        );
         new MySqlBindingsPropertiesProcessor().process(environment, bindings, properties);
         assertThat(properties)
                 .containsEntry("spring.datasource.driver-class-name", "org.mariadb.jdbc.Driver")
@@ -60,8 +59,25 @@ final class MySqlBindingsPropertiesProcessorTest {
     }
 
     @Test
-    @DisplayName("contributes r2dbc properties")
+    @DisplayName("gives precedence to jdbc-url")
+    void testJdbcURL() {
+        Bindings bindings = new Bindings(
+                new Binding("test-name", Paths.get("test-path"), secret.withEntry("jdbc-url", "test-jdbc-url"))
+        );
+        new MySqlBindingsPropertiesProcessor().process(environment, bindings, properties);
+        assertThat(properties)
+                .containsEntry("spring.datasource.driver-class-name", "org.mariadb.jdbc.Driver")
+                .containsEntry("spring.datasource.password", "test-password")
+                .containsEntry("spring.datasource.url", "test-jdbc-url")
+                .containsEntry("spring.datasource.username", "test-username");
+    }
+
+    @Test
+    @DisplayName("composes r2dbc url from host port and database")
     void testR2dbc() {
+        Bindings bindings = new Bindings(
+                new Binding("test-name", Paths.get("test-path"), secret)
+        );
         new MySqlBindingsPropertiesProcessor().process(environment, bindings, properties);
         assertThat(properties)
                 .containsEntry("spring.r2dbc.password", "test-password")
@@ -70,8 +86,24 @@ final class MySqlBindingsPropertiesProcessorTest {
     }
 
     @Test
+    @DisplayName("gives precedence to r2dbc-url")
+    void testR2dbcURL() {
+        Bindings bindings = new Bindings(
+                new Binding("test-name", Paths.get("test-path"), secret.withEntry("r2dbc-url", "test-r2dbc-url"))
+        );
+        new MySqlBindingsPropertiesProcessor().process(environment, bindings, properties);
+        assertThat(properties)
+                .containsEntry("spring.r2dbc.password", "test-password")
+                .containsEntry("spring.r2dbc.url", "test-r2dbc-url")
+                .containsEntry("spring.r2dbc.username", "test-username");
+    }
+
+    @Test
     @DisplayName("can be disabled")
     void disabled() {
+        Bindings bindings = new Bindings(
+                new Binding("test-name", Paths.get("test-path"), secret)
+        );
         environment.setProperty("org.springframework.cloud.bindings.boot.mysql.enable", "false");
 
         new MySqlBindingsPropertiesProcessor().process(environment, bindings, properties);

--- a/src/test/java/org/springframework/cloud/bindings/boot/OracleBindingsPropertiesProcessorTest.java
+++ b/src/test/java/org/springframework/cloud/bindings/boot/OracleBindingsPropertiesProcessorTest.java
@@ -32,25 +32,24 @@ import static org.springframework.cloud.bindings.boot.OracleBindingsPropertiesPr
 @DisplayName("Oracle BindingsPropertiesProcessor")
 final class OracleBindingsPropertiesProcessorTest {
 
-    private final Bindings bindings = new Bindings(
-            new Binding("test-name", Paths.get("test-path"),
-                    new FluentMap()
-                            .withEntry(Binding.TYPE, TYPE)
-                            .withEntry("database", "test-database")
-                            .withEntry("host", "test-host")
-                            .withEntry("password", "test-password")
-                            .withEntry("port", "test-port")
-                            .withEntry("username", "test-username")
-            )
-    );
+    private final FluentMap secret = new FluentMap()
+            .withEntry(Binding.TYPE, TYPE)
+            .withEntry("database", "test-database")
+            .withEntry("host", "test-host")
+            .withEntry("password", "test-password")
+            .withEntry("port", "test-port")
+            .withEntry("username", "test-username");
 
     private final MockEnvironment environment = new MockEnvironment();
 
     private final HashMap<String, Object> properties = new HashMap<>();
 
     @Test
-    @DisplayName("contributes jdbc properties")
+    @DisplayName("composes jdbc url from host port and database")
     void testJdbc() {
+        Bindings bindings = new Bindings(
+                new Binding("test-name", Paths.get("test-path"), secret)
+        );
         new OracleBindingsPropertiesProcessor().process(environment, bindings, properties);
         assertThat(properties)
                 .containsEntry("spring.datasource.driver-class-name", "oracle.jdbc.OracleDriver")
@@ -60,8 +59,25 @@ final class OracleBindingsPropertiesProcessorTest {
     }
 
     @Test
-    @DisplayName("contributes r2dbc properties")
+    @DisplayName("gives precedence to jdbc-url")
+    void testJdbcURL() {
+        Bindings bindings = new Bindings(
+                new Binding("test-name", Paths.get("test-path"), secret.withEntry("jdbc-url", "test-jdbc-url"))
+        );
+        new OracleBindingsPropertiesProcessor().process(environment, bindings, properties);
+        assertThat(properties)
+                .containsEntry("spring.datasource.driver-class-name", "oracle.jdbc.OracleDriver")
+                .containsEntry("spring.datasource.password", "test-password")
+                .containsEntry("spring.datasource.url", "test-jdbc-url")
+                .containsEntry("spring.datasource.username", "test-username");
+    }
+
+    @Test
+    @DisplayName("composes r2dbc url from host port and database")
     void testR2dbc() {
+        Bindings bindings = new Bindings(
+                new Binding("test-name", Paths.get("test-path"), secret)
+        );
         new OracleBindingsPropertiesProcessor().process(environment, bindings, properties);
         assertThat(properties)
                 .containsEntry("spring.r2dbc.password", "test-password")
@@ -70,8 +86,24 @@ final class OracleBindingsPropertiesProcessorTest {
     }
 
     @Test
+    @DisplayName("gives precedence to r2dbc-url")
+    void testR2dbcURL() {
+        Bindings bindings = new Bindings(
+                new Binding("test-name", Paths.get("test-path"), secret.withEntry("r2dbc-url", "test-r2dbc-url"))
+        );
+        new OracleBindingsPropertiesProcessor().process(environment, bindings, properties);
+        assertThat(properties)
+                .containsEntry("spring.r2dbc.password", "test-password")
+                .containsEntry("spring.r2dbc.url", "test-r2dbc-url")
+                .containsEntry("spring.r2dbc.username", "test-username");
+    }
+
+    @Test
     @DisplayName("can be disabled")
     void disabled() {
+        Bindings bindings = new Bindings(
+                new Binding("test-name", Paths.get("test-path"), secret)
+        );
         environment.setProperty("org.springframework.cloud.bindings.boot.oracle.enable", "false");
 
         new OracleBindingsPropertiesProcessor().process(environment, bindings, properties);

--- a/src/test/java/org/springframework/cloud/bindings/boot/PostgreSqlBindingsPropertiesProcessorTest.java
+++ b/src/test/java/org/springframework/cloud/bindings/boot/PostgreSqlBindingsPropertiesProcessorTest.java
@@ -32,25 +32,24 @@ import static org.springframework.cloud.bindings.boot.PostgreSqlBindingsProperti
 @DisplayName("PostgreSQL BindingsPropertiesProcessor")
 final class PostgreSqlBindingsPropertiesProcessorTest {
 
-    private final Bindings bindings = new Bindings(
-            new Binding("test-name", Paths.get("test-path"),
-                    new FluentMap()
-                            .withEntry(Binding.TYPE, TYPE)
-                            .withEntry("database", "test-database")
-                            .withEntry("host", "test-host")
-                            .withEntry("password", "test-password")
-                            .withEntry("port", "test-port")
-                            .withEntry("username", "test-username")
-            )
-    );
+    private final FluentMap secret = new FluentMap()
+            .withEntry(Binding.TYPE, TYPE)
+            .withEntry("database", "test-database")
+            .withEntry("host", "test-host")
+            .withEntry("password", "test-password")
+            .withEntry("port", "test-port")
+            .withEntry("username", "test-username");
 
     private final MockEnvironment environment = new MockEnvironment();
 
     private final HashMap<String, Object> properties = new HashMap<>();
 
     @Test
-    @DisplayName("contributes jdbc properties")
+    @DisplayName("composes jdbc url from host port and database")
     void testJdbc() {
+        Bindings bindings = new Bindings(
+                new Binding("test-name", Paths.get("test-path"), secret)
+        );
         new PostgreSqlBindingsPropertiesProcessor().process(environment, bindings, properties);
         assertThat(properties)
                 .containsEntry("spring.datasource.driver-class-name", "org.postgresql.Driver")
@@ -60,8 +59,25 @@ final class PostgreSqlBindingsPropertiesProcessorTest {
     }
 
     @Test
-    @DisplayName("contributes r2dbc properties")
+    @DisplayName("gives precedence to jdbc-url")
+    void testJdbcURL() {
+        Bindings bindings = new Bindings(
+                new Binding("test-name", Paths.get("test-path"), secret.withEntry("jdbc-url", "test-jdbc-url"))
+        );
+        new PostgreSqlBindingsPropertiesProcessor().process(environment, bindings, properties);
+        assertThat(properties)
+                .containsEntry("spring.datasource.driver-class-name", "org.postgresql.Driver")
+                .containsEntry("spring.datasource.password", "test-password")
+                .containsEntry("spring.datasource.url", "test-jdbc-url")
+                .containsEntry("spring.datasource.username", "test-username");
+    }
+
+    @Test
+    @DisplayName("composes r2dbc url from host port and database")
     void testR2dbc() {
+        Bindings bindings = new Bindings(
+                new Binding("test-name", Paths.get("test-path"), secret)
+        );
         new PostgreSqlBindingsPropertiesProcessor().process(environment, bindings, properties);
         assertThat(properties)
                 .containsEntry("spring.r2dbc.password", "test-password")
@@ -70,8 +86,24 @@ final class PostgreSqlBindingsPropertiesProcessorTest {
     }
 
     @Test
+    @DisplayName("gives precedence to r2dbc-url")
+    void testR2dbcURL() {
+        Bindings bindings = new Bindings(
+                new Binding("test-name", Paths.get("test-path"), secret.withEntry("r2dbc-url", "test-r2dbc-url"))
+        );
+        new PostgreSqlBindingsPropertiesProcessor().process(environment, bindings, properties);
+        assertThat(properties)
+                .containsEntry("spring.r2dbc.password", "test-password")
+                .containsEntry("spring.r2dbc.url", "test-r2dbc-url")
+                .containsEntry("spring.r2dbc.username", "test-username");
+    }
+
+    @Test
     @DisplayName("can be disabled")
     void disabled() {
+        Bindings bindings = new Bindings(
+                new Binding("test-name", Paths.get("test-path"), secret)
+        );
         environment.setProperty("org.springframework.cloud.bindings.boot.postgresql.enable", "false");
 
         new PostgreSqlBindingsPropertiesProcessor().process(environment, bindings, properties);


### PR DESCRIPTION
Previously Spring Cloud Bindings always composed spring.datasource.url from the host port and database properties. This is limiting in that it does not provide a mechanism for users to specify jdbc properties (e.g. sslMode). The PR retains the original behavior but also respects jdbc-url and r2dbc-url keys in all RDBS bindings. The explicit jdbc-url and r2dbc-url keys take precedence over the composed value.

Signed-off-by: Emily Casey <ecasey@vmware.com>