### PR TITLE
Mention K8s Service Binding Spec in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Spring Cloud Bindings
-The Spring Cloud Bindings library exposes a rich Java language binding for the [Cloud Native Buildpacks Binding Specification][s].  In addition, if opted-in, it configures Spring Boot application configuration properties appropriate for the type of binding encountered.
+The Spring Cloud Bindings library exposes a rich Java language binding for the [Kubernetes Service Binding Specification][s].  In addition, if opted-in, it configures Spring Boot application configuration properties appropriate for the type of binding encountered.
 
-[s]: https://github.com/buildpacks/spec/blob/master/extensions/bindings.md
+[s]: https://github.com/servicebinding/spec
 
 ## Library Usage
 While less used, explicit binding access can be achieved through the `Bindings` type.


### PR DESCRIPTION
Judging from comments in the [Bindings](https://github.com/spring-cloud/spring-cloud-bindings/blob/main/src/main/java/org/springframework/cloud/bindings/Bindings.java) and [Binding](https://github.com/spring-cloud/spring-cloud-bindings/blob/main/src/main/java/org/springframework/cloud/bindings/Binding.java) class the Kubernetes Service Binding Specification superseded the Cloud Native Buildpacks Binding Specification.
The library supports both but seems to view the Kubernetes Service Binding Specification as the leading specification.
I updated the README to reflect this and to avoid to lead users to the "legacy" specification.

This also avoids confusion, when being linked from the servicebinding.io's [list of libraries](https://servicebinding.io/application-developer/) to this page, however finding a different binding specification in the README.