### PR TITLE
add support for redirect-uris key for oauth2 bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Disable Property: `org.springframework.cloud.bindings.boot.oauth2.enable`
 | `spring.security.oauth2.client.registration.{name}.client-name` | `{client-name}`
 | `spring.security.oauth2.client.registration.{name}.client-authentication-method` | `{client-authentication-method}`
 | `spring.security.oauth2.client.registration.{name}.authorization-grant-type` | `{authorization-grant-type}` or if not set then `{authorization-grant-types}` if it contains only one value (comma-separated)
-| `spring.security.oauth2.client.registration.{name}.redirect-uri` | `{redirect-uri}`
+| `spring.security.oauth2.client.registration.{name}.redirect-uri` | `{redirect-uri}` or if not set then `{redirect-uris}` if it contains only one value (comma-separated)
 | `spring.security.oauth2.client.registration.{name}.scope` | `{scope}`
 | `spring.security.oauth2.client.provider.{provider}.issuer-uri` | `{issuer-uri}`
 | `spring.security.oauth2.client.provider.{provider}.authorization-uri` | `{authorization-uri}`

--- a/src/main/java/org/springframework/cloud/bindings/boot/SpringSecurityOAuth2BindingsPropertiesProcessor.java
+++ b/src/main/java/org/springframework/cloud/bindings/boot/SpringSecurityOAuth2BindingsPropertiesProcessor.java
@@ -64,6 +64,9 @@ public final class SpringSecurityOAuth2BindingsPropertiesProcessor implements Bi
                     .when(SpringSecurityOAuth2BindingsPropertiesProcessor::hasSingleValue)
                     .toIfAbsent(String.format("spring.security.oauth2.client.registration.%s.authorization-grant-type", clientName));
             map.from("redirect-uri").to(String.format("spring.security.oauth2.client.registration.%s.redirect-uri", clientName));
+            map.from("redirect-uris")
+                    .when(SpringSecurityOAuth2BindingsPropertiesProcessor::hasSingleValue)
+                    .toIfAbsent(String.format("spring.security.oauth2.client.registration.%s.redirect-uri", clientName));
             map.from("scope").to(String.format("spring.security.oauth2.client.registration.%s.scope", clientName));
             map.from("client-name").to(String.format("spring.security.oauth2.client.registration.%s.client-name", clientName));
             map.from("issuer-uri").to(String.format("spring.security.oauth2.client.provider.%s.issuer-uri", provider));

--- a/src/test/java/org/springframework/cloud/bindings/boot/SpringSecurityOAuth2BindingsPropertiesProcessorTest.java
+++ b/src/test/java/org/springframework/cloud/bindings/boot/SpringSecurityOAuth2BindingsPropertiesProcessorTest.java
@@ -167,6 +167,49 @@ final class SpringSecurityOAuth2BindingsPropertiesProcessorTest {
     }
 
     @Test
+    @DisplayName("contributes a redirect-uri is there is only one in redirect-uris")
+    void testRedirectUrisOneEntry() {
+        Bindings bindings = new Bindings(new Binding("binding-name", Paths.get("test-path"),
+                new FluentMap()
+                        .withEntry(Binding.TYPE, TYPE)
+                        .withEntry("provider", "some-provider")
+                        .withEntry("redirect-uris", "https://app.example.com/authorized")
+        ));
+        new SpringSecurityOAuth2BindingsPropertiesProcessor().process(new MockEnvironment(), bindings, properties);
+        assertThat(properties)
+                .containsEntry("spring.security.oauth2.client.registration.binding-name.redirect-uri", "https://app.example.com/authorized");
+    }
+
+    @Test
+    @DisplayName("does not contributes a redirect-uri is there are multiple entries in redirect-uris")
+    void testRedirectUrisMultipleEntries() {
+        Bindings bindings = new Bindings(new Binding("binding-name", Paths.get("test-path"),
+                new FluentMap()
+                        .withEntry(Binding.TYPE, TYPE)
+                        .withEntry("provider", "some-provider")
+                        .withEntry("redirect-uris", "https://app.example.com/authorized,https://other-app.example.com/login")
+        ));
+        new SpringSecurityOAuth2BindingsPropertiesProcessor().process(new MockEnvironment(), bindings, properties);
+        assertThat(properties)
+                .doesNotContainKey("spring.security.oauth2.client.registration.binding-name.redirect-uri");
+    }
+
+    @Test
+    @DisplayName("uses the value from redirect-uri if redirect-uris is also present")
+    void testRedirectUriAndRedirectUris() {
+        Bindings bindings = new Bindings(new Binding("binding-name", Paths.get("test-path"),
+                new FluentMap()
+                        .withEntry(Binding.TYPE, TYPE)
+                        .withEntry("provider", "some-provider")
+                        .withEntry("redirect-uris", "https://app.example.com/authorized")
+                        .withEntry("redirect-uri", "https://other-app.example.com/login")
+        ));
+        new SpringSecurityOAuth2BindingsPropertiesProcessor().process(new MockEnvironment(), bindings, properties);
+        assertThat(properties)
+                .containsEntry("spring.security.oauth2.client.registration.binding-name.redirect-uri", "https://other-app.example.com/login");
+    }
+
+    @Test
     @DisplayName("can be disabled")
     void disabled() {
         environment.setProperty("org.springframework.cloud.bindings.boot.oauth2.enable", "false");


### PR DESCRIPTION
Similar to #69, but for `redirect-uri(s)`.

When registering a client with an IDP, it is often possible to register multiple redirect URIs for that client, e.g. one for local testing and one for prod. In that case, the binding may contain multiple redirect uris. With this change, we will auto-configure Boot apps when there is a single value in the `redirect-uris` field (plural).