### PR TITLE
Fix connection url for Oracle and SqlServer

### DIFF
--- a/src/main/java/org/springframework/cloud/bindings/boot/OracleBindingsPropertiesProcessor.java
+++ b/src/main/java/org/springframework/cloud/bindings/boot/OracleBindingsPropertiesProcessor.java
@@ -49,7 +49,7 @@ public final class OracleBindingsPropertiesProcessor implements BindingsProperti
             map.from("username").to("spring.datasource.username");
             map.from("password").to("spring.datasource.password");
             map.from("host", "port", "database").to("spring.datasource.url",
-                    (host, port, database) -> String.format("jdbc:oracle://%s:%s/%s", host, port, database));
+                    (host, port, database) -> String.format("jdbc:oracle:thin:@%s:%s/%s", host, port, database));
 
             // jdbcURL takes precedence
             map.from("jdbc-url").to("spring.datasource.url");

--- a/src/main/java/org/springframework/cloud/bindings/boot/SqlServerBindingsPropertiesProcessor.java
+++ b/src/main/java/org/springframework/cloud/bindings/boot/SqlServerBindingsPropertiesProcessor.java
@@ -48,7 +48,7 @@ public final class SqlServerBindingsPropertiesProcessor implements BindingsPrope
             //jdbc properties
             map.from("password").to("spring.datasource.password");
             map.from("host", "port", "database").to("spring.datasource.url",
-                    (host, port, database) -> String.format("jdbc:sqlserver://%s:%s/%s", host, port, database));
+                    (host, port, database) -> String.format("jdbc:sqlserver://%s:%s;databaseName=%s", host, port, database));
             map.from("username").to("spring.datasource.username");
 
             // jdbcURL takes precedence

--- a/src/test/java/org/springframework/cloud/bindings/boot/OracleBindingsPropertiesProcessorTest.java
+++ b/src/test/java/org/springframework/cloud/bindings/boot/OracleBindingsPropertiesProcessorTest.java
@@ -54,7 +54,7 @@ final class OracleBindingsPropertiesProcessorTest {
         assertThat(properties)
                 .containsEntry("spring.datasource.driver-class-name", "oracle.jdbc.OracleDriver")
                 .containsEntry("spring.datasource.password", "test-password")
-                .containsEntry("spring.datasource.url", "jdbc:oracle://test-host:test-port/test-database")
+                .containsEntry("spring.datasource.url", "jdbc:oracle:thin:@test-host:test-port/test-database")
                 .containsEntry("spring.datasource.username", "test-username");
     }
 

--- a/src/test/java/org/springframework/cloud/bindings/boot/SqlServerBindingsPropertiesProcessorTest.java
+++ b/src/test/java/org/springframework/cloud/bindings/boot/SqlServerBindingsPropertiesProcessorTest.java
@@ -54,7 +54,7 @@ final class SqlServerBindingsPropertiesProcessorTest {
         assertThat(properties)
                 .containsEntry("spring.datasource.driver-class-name", "com.microsoft.sqlserver.jdbc.SQLServerDriver")
                 .containsEntry("spring.datasource.password", "test-password")
-                .containsEntry("spring.datasource.url", "jdbc:sqlserver://test-host:test-port/test-database")
+                .containsEntry("spring.datasource.url", "jdbc:sqlserver://test-host:test-port;databaseName=test-database")
                 .containsEntry("spring.datasource.username", "test-username");
     }
 


### PR DESCRIPTION
Update the connection url for Oracle and SqlServer that is generated by `spring-cloud-bindings`.

fixes: https://github.com/spring-cloud/spring-cloud-bindings/issues/82