### PR TITLE
Bump to Sprint Boot 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Disable Property: `org.springframework.cloud.bindings.boot.artemis.enable`
 
 | Property                                            | Value                                  |
 | --------------------------------------------------- | -------------------------------------- |
-| `spring.artemis.host`                               | `{host}`                               |
+| `spring.artemis.broker-url`                         | `{broker-url}`                         |
 | `spring.artemis.mode`                               | `{mode}`                               |
 | `spring.artemis.password`                           | `{password}`                           |
 | `spring.artemis.port`                               | `{port}`                               |
@@ -65,30 +65,31 @@ Disable Property: `org.springframework.cloud.bindings.boot.artemis.enable`
 Type: `cassandra`
 Disable Property: `org.springframework.cloud.bindings.boot.cassandra.enable`
 
-| Property                               | Value              |
-| -------------------------------------- | ------------------ |
-| `spring.data.cassandra.cluster-name`   | `{cluster-name}`   |
-| `spring.data.cassandra.compression`    | `{compression}`    |
-| `spring.data.cassandra.contact-points` | `{contact-points}` |
-| `spring.data.cassandra.keyspace-name`  | `{keyspace-name}`  |
-| `spring.data.cassandra.password`       | `{password}`       |
-| `spring.data.cassandra.port`           | `{port}`           |
-| `spring.data.cassandra.ssl`            | `{ssl}`            |
-| `spring.data.cassandra.username`       | `{username}`       |
+| Property                                                     | Value                                         |
+|--------------------------------------------------------------|-----------------------------------------------|
+| `spring.data.cassandra.cluster-name`                         | `{cluster-name}`                              |
+| `spring.data.cassandra.compression`                          | `{compression}`                               |
+| `spring.data.cassandra.contact-points`                       | `{contact-points}`                            |
+| `spring.data.cassandra.keyspace-name`                        | `{keyspace-name}`                             |
+| `spring.data.cassandra.password`                             | `{password}`                                  |
+| `spring.data.cassandra.port`                                 | `{port}`                                      |
+| `spring.data.cassandra.ssl`                                  | `{ssl}`                                       |
+| `spring.data.cassandra.username`                             | `{username}`                                  |
+| `spring.cassandra.request.throttler.drain-interval`          | `{request.throttler.drain-interval}`          |
+| `spring.cassandra.request.throttler.max-concurrent-requests` | `{request.throttler.max-concurrent-requests}` |
+| `spring.cassandra.request.throttler.max-queue-size`          | `{request.throttler.max-queue-size}`          |
+| `spring.cassandra.request.throttler.max-requests-per-second` | `{request.throttler.max-requests-per-second}` |
 
 ### Couchbase
 Type: `couchbase`
 Disable Property: `org.springframework.cloud.bindings.boot.couchbase.enable`
 
-| Property                                          | Value                              |
-| ------------------------------------------------- | ---------------------------------- |
-| `spring.couchbase.bootstrap-hosts`                | `{bootstrap-hosts}`                |
-| `spring.couchbase.bucket.name`                    | `{bucket.name}`                    |
-| `spring.couchbase.bucket.password`                | `{bucket.passsword}`               |
-| `spring.couchbase.env.bootstrap.http-direct-port` | `{env.bootstrap.http-direct-port}` |
-| `spring.couchbase.env.bootstrap.http-ssl-port`    | `{env.bootstrap.http-ssl-port}`    |
-| `spring.couchbase.password`                       | `{password}`                       |
-| `spring.couchbase.username`                       | `{username}`                       |
+| Property                                          | Value                     |
+|---------------------------------------------------|---------------------------|
+| `spring.couchbase.connection-string`              | `{connection-string}`     |
+| `spring.couchbase.password`                       | `{password}`              |
+| `spring.couchbase.username`                       | `{username}`              |
+| `spring.data.couchbase.bucket-name`               | `{bucket-name}`           |
 
 ### DB2 RDBMS
 Type: `db2`
@@ -109,19 +110,11 @@ Disable Property: `org.springframework.cloud.bindings.boot.db2.enable`
 Type: `elasticsearch`
 Disable Property: `org.springframework.cloud.bindings.boot.elasticsearch.enable`
 
-| Property                                              | Value          |
-| ----------------------------------------------------- | -------------- |
-| `spring.data.elasticsearch.client.reactive.endpoints` | `{endpoints}`  |
-| `spring.data.elasticsearch.client.reactive.password`  | `{password}`   |
-| `spring.data.elasticsearch.client.reactive.use-ssl`   | `{use-ssl}`    |
-| `spring.data.elasticsearch.client.reactive.username`  | `{username}`   |
-| `spring.elasticsearch.jest.password`                  | `{password}`   |
-| `spring.elasticsearch.jest.proxy.host`                | `{proxy.host}` |
-| `spring.elasticsearch.jest.proxy.port`                | `{proxy.port}` |
-| `spring.elasticsearch.jest.username`                  | `{username}`   |
-| `spring.elasticsearch.rest.password`                  | `{password}`   |
-| `spring.elasticsearch.rest.uris`                      | `{uris}`       |
-| `spring.elasticsearch.rest.username`                  | `{username}`   |
+| Property                        | Value         |
+|---------------------------------|---------------|
+| `spring.elasticsearch.password` | `{password}`  |
+| `spring.elasticsearch.uris`     | `{uris}`      |
+| `spring.elasticsearch.username` | `{username}`  |
 
 ### Kafka
 Type: `kafka`
@@ -180,11 +173,11 @@ Disable Property: `org.springframework.cloud.bindings.boot.mysql.enable`
 Type: `neo4j`
 Disable Property: `org.springframework.cloud.bindings.boot.neo4j.enable`
 
-| Property                     | Value        |
-| ---------------------------- | ------------ |
-| `spring.data.neo4j.password` | `{password}` |
-| `spring.data.neo4j.uri`      | `{uri}`      |
-| `spring.data.neo4j.username` | `{username}` |
+| Property                                | Value          |
+|-----------------------------------------|----------------|
+| `spring.neo4j.authentication.password`  | `{password}`   |
+| `spring.neo4j.uri`                      | `{uri}`        |
+| `spring.neo4j.authentication.username`  | `{username}`   |
 
 ### Oracle RDBMS
 Type: `oracle`
@@ -231,19 +224,19 @@ Disable Property: `org.springframework.cloud.bindings.boot.rabbitmq.enable`
 Type: `redis`
 Disable Property: `org.springframework.cloud.bindings.boot.redis.enable`
 
-| Property                             | Value                     |
-| ------------------------------------ | ------------------------- |
-| `spring.redis.client-name`           | `{client-name}`           |
-| `spring.redis.cluster.max-redirects` | `{cluster.max-redirects}` |
-| `spring.redis.cluster.nodes`         | `{cluster.nodes}`         |
-| `spring.redis.database`              | `{database}`              |
-| `spring.redis.host`                  | `{host}`                  |
-| `spring.redis.password`              | `{password}`              |
-| `spring.redis.port`                  | `{port}`                  |
-| `spring.redis.sentinel.master`       | `{sentinel.master}`       |
-| `spring.redis.sentinel.nodes`        | `{sentinel.nodes}`        |
-| `spring.redis.ssl`                   | `{ssl}`                   |
-| `spring.redis.url`                   | `{url}`                   |
+| Property                                  | Value                     |
+|-------------------------------------------|---------------------------|
+| `spring.data.redis.client-name`           | `{client-name}`           |
+| `spring.data.redis.cluster.max-redirects` | `{cluster.max-redirects}` |
+| `spring.data.redis.cluster.nodes`         | `{cluster.nodes}`         |
+| `spring.data.redis.database`              | `{database}`              |
+| `spring.data.redis.host`                  | `{host}`                  |
+| `spring.data.redis.password`              | `{password}`              |
+| `spring.data.redis.port`                  | `{port}`                  |
+| `spring.data.redis.sentinel.master`       | `{sentinel.master}`       |
+| `spring.data.redis.sentinel.nodes`        | `{sentinel.nodes}`        |
+| `spring.data.redis.ssl`                   | `{ssl}`                   |
+| `spring.data.redis.url`                   | `{url}`                   |
 
 ### SAP Hana
 Type: `hana`
@@ -346,25 +339,29 @@ If `{authentication-method}` is equal to `aws_ec2`:
 | `spring.cloud.vault.aws-ec2.role`              | `{role}`                               |
 
 If `{authentication-method}` is equal to `aws_iam`:
-| Property                                  | Value                    |
-| ----------------------------------------- | ------------------------ |
-| `spring.cloud.vault.aws-iam.aws-path`     | `{aws-path}`             |
-| `spring.cloud.vault.aws-iam.endpoint-uri` | `{aws-sts-endpoint-uri}` |
-| `spring.cloud.vault.aws-iam.role`         | `{role}`                 |
-| `spring.cloud.vault.aws-iam.server-id`    | `{aws-iam-server-id}`    |
+| Property                                  | Value                     |
+|-------------------------------------------|---------------------------|
+| `spring.cloud.vault.aws-iam.aws-path`     | `{aws-path}`              |
+| `spring.cloud.vault.aws-iam.endpoint-uri` | `{aws-sts-endpoint-uri}`  |
+| `spring.cloud.vault.aws-iam.role`         | `{role}`                  |
+| `spring.cloud.vault.aws-iam.server-name`  | `{aws-iam-server-name}`   |
 
 If `{authentication-method}` is equal to `azure_msi`:
-| Property                                  | Value          |
-| ----------------------------------------- | -------------- |
-| `spring.cloud.vault.azure-msi.azure-path` | `{azure-path}` |
-| `spring.cloud.vault.azure-msi.role`       | `{role}`       |
+| Property                                              | Value                      |
+|-------------------------------------------------------|----------------------------|
+| `spring.cloud.vault.azure-msi.azure-path`             | `{azure-path}`             |
+| `spring.cloud.vault.azure-msi.role`                   | `{role}`                   |
+| `spring.cloud.vault.azure-msi.metadata-service`       | `{metadata-service}`       |
+| `spring.cloud.vault.azure-msi.identity-token-service` | `{identity-token-service}` |
 
 If `{authentication-method}` is equal to `cert`:
-| Property                                    | Value                                         |
-| ------------------------------------------- | --------------------------------------------- |
-| `spring.cloud.vault.ssl.cert-auth-path`     | `{cert-auth-path}`                            |
-| `spring.cloud.vault.ssl.key-store-password` | `{key-store-password}`                        |
-| `spring.cloud.vault.ssl.key-store`          | `${SERVICE_BINDING_ROOT}/{name}/keystore.jks` |
+| Property                                      | Value                                           |
+|-----------------------------------------------|-------------------------------------------------|
+| `spring.cloud.vault.ssl.cert-auth-path`       | `{cert-auth-path}`                              |
+| `spring.cloud.vault.ssl.key-store`            | `${SERVICE_BINDING_ROOT}/{name}/keystore.jks`   |
+| `spring.cloud.vault.ssl.key-store-password`   | `{key-store-password}`                          |
+| `spring.cloud.vault.ssl.trust-store`          | `${SERVICE_BINDING_ROOT}/{name}/truststore.jks` |
+| `spring.cloud.vault.ssl.trust-store-password` | `{key-store-password}`                          |
 
 If `{authentication-method}` is equal to `cubbyhole`:
 | Property                   | Value     |
@@ -378,23 +375,23 @@ If `{authentication-method}` is equal to `gcp_gce`:
 | `spring.cloud.vault.gcp-gce.role`            | `{role}`                |
 | `spring.cloud.vault.gcp-gce.service-account` | `{gcp-service-account}` |
 
-
 If `{authentication-method}` is equal to `gcp_iam`:
-| Property                                             | Value                                             |
-| ---------------------------------------------------- | ------------------------------------------------- |
-| `spring.cloud.vault.gcp-iam.credentials.encoded-key` | `{encoded-key}`                                   |
-| `spring.cloud.vault.gcp-iam.credentials.location`    | `${SERVICE_BINDING_ROOT}/{name}/credentials.json` |
-| `spring.cloud.vault.gcp-iam.gcp-path`                | `{gcp-path}`                                      |
-| `spring.cloud.vault.gcp-iam.jwt-validity`            | `{jwt-validity}`                                  |
-| `spring.cloud.vault.gcp-iam.project-id`              | `{gcp-project-id}`                                |
-| `spring.cloud.vault.gcp-iam.role`                    | `{role}`                                          |
-| `spring.cloud.vault.gcp-iam.service-account`         | `{gcp-service-account}`                           |
+| Property                                             | Value                                              |
+|------------------------------------------------------|----------------------------------------------------|
+| `spring.cloud.vault.gcp-iam.credentials.encoded-key` | `{encoded-key}`                                    |
+| `spring.cloud.vault.gcp-iam.credentials.location`    | `${SERVICE_BINDING_ROOT}/{name}/credentials.json`  |
+| `spring.cloud.vault.gcp-iam.gcp-path`                | `{gcp-path}`                                       |
+| `spring.cloud.vault.gcp-iam.jwt-validity`            | `{jwt-validity}`                                   |
+| `spring.cloud.vault.gcp-iam.project-id`              | `{gcp-project-id}`                                 |
+| `spring.cloud.vault.gcp-iam.role`                    | `{role}`                                           |
+| `spring.cloud.vault.gcp-iam.service-account-id`      | `{gcp-service-account}`                            |
 
 If `{authentication-method}` is equal to `kubernetes`:
-| Property                                        | Value               |
-| ----------------------------------------------- | ------------------- |
-| `spring.cloud.vault.kubernetes.kubernetes-path` | `{kubernetes-path}` |
-| `spring.cloud.vault.kubernetes.role`            | `{role}`            |
+| Property                                                              | Value                                     |
+|-----------------------------------------------------------------------|-------------------------------------------|
+| `spring.cloud.vault.kubernetes.role`                                  | `{role}`                                  |
+| `spring.cloud.vault.kubernetes.kubernetes-path`                       | `{kubernetes-path}`                       |
+| `spring.cloud.vault.kubernetes.kubernetes-service-account-token-file` | `{kubernetes-service-account-token-file}` |
 
 If `{authentication-method}` is equal to `token`:
 | Property                   | Value     |

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <java.version>1.8</java.version>
         <jsr305.version>3.0.2</jsr305.version>
         <mariadb-r2dbc.version>1.1.2</mariadb-r2dbc.version>
-        <spring-boot.version>2.3.3.RELEASE</spring-boot.version>
+        <spring-boot.version>2.4.13</spring-boot.version>
 
         <!-- Plugins -->
         <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <java.version>1.8</java.version>
         <jsr305.version>3.0.2</jsr305.version>
-        <mariadb-r2dbc.version>1.0.3</mariadb-r2dbc.version>
+        <mariadb-r2dbc.version>1.1.2</mariadb-r2dbc.version>
         <spring-boot.version>2.3.3.RELEASE</spring-boot.version>
 
         <!-- Plugins -->

--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,9 @@
         <spring-boot.version>2.3.3.RELEASE</spring-boot.version>
 
         <!-- Plugins -->
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
         <maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,10 +32,10 @@
     </developers>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>17</java.version>
         <jsr305.version>3.0.2</jsr305.version>
         <mariadb-r2dbc.version>1.1.2</mariadb-r2dbc.version>
-        <spring-boot.version>2.4.13</spring-boot.version>
+        <spring-boot.version>3.0.0</spring-boot.version>
 
         <!-- Plugins -->
         <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>

--- a/src/main/java/org/springframework/cloud/bindings/boot/ArtemisBindingsPropertiesProcessor.java
+++ b/src/main/java/org/springframework/cloud/bindings/boot/ArtemisBindingsPropertiesProcessor.java
@@ -43,10 +43,9 @@ public final class ArtemisBindingsPropertiesProcessor implements BindingsPropert
         bindings.filterBindings(TYPE).forEach(binding -> {
             MapMapper map = new MapMapper(binding.getSecret(), properties);
 
-            map.from("host").to("spring.artemis.host");
+            map.from("broker-url").to("spring.artemis.broker-url");
             map.from("mode").to("spring.artemis.mode");
             map.from("password").to("spring.artemis.password");
-            map.from("port").to("spring.artemis.port");
             map.from("user").to("spring.artemis.user");
 
             map.from("embedded.cluster-password").to("spring.artemis.embedded.cluster-password");
@@ -57,14 +56,14 @@ public final class ArtemisBindingsPropertiesProcessor implements BindingsPropert
             map.from("embedded.server-id").to("spring.artemis.embedded.server-id");
             map.from("embedded.topics").to("spring.artemis.embedded.topics");
 
-            map.from("pool.block-if-full").to("spring.rabbitmq.pool.block-if-full");
-            map.from("pool.block-if-full-timeout").to("spring.rabbitmq.pool.block-if-full-timeout");
-            map.from("pool.enabled").to("spring.rabbitmq.pool.enabled");
-            map.from("pool.idle-timeout").to("spring.rabbitmq.pool.idle-timeout");
-            map.from("pool.max-connections").to("spring.rabbitmq.pool.max-connections");
-            map.from("pool.max-sessions-per-connection").to("spring.rabbitmq.pool.max-sessions-per-connection");
-            map.from("pool.time-between-expiration-check").to("spring.rabbitmq.pool.time-between-expiration-check");
-            map.from("pool.use-anonymous-producers").to("spring.rabbitmq.pool.use-anonymous-producers");
+            map.from("pool.block-if-full").to("spring.artemis.pool.block-if-full");
+            map.from("pool.block-if-full-timeout").to("spring.artemis.pool.block-if-full-timeout");
+            map.from("pool.enabled").to("spring.artemis.pool.enabled");
+            map.from("pool.idle-timeout").to("spring.artemis.pool.idle-timeout");
+            map.from("pool.max-connections").to("spring.artemis.pool.max-connections");
+            map.from("pool.max-sessions-per-connection").to("spring.artemis.pool.max-sessions-per-connection");
+            map.from("pool.time-between-expiration-check").to("spring.artemis.pool.time-between-expiration-check");
+            map.from("pool.use-anonymous-producers").to("spring.artemis.pool.use-anonymous-producers");
         });
     }
 

--- a/src/main/java/org/springframework/cloud/bindings/boot/BindingFlattenedEnvironmentPostProcessor.java
+++ b/src/main/java/org/springframework/cloud/bindings/boot/BindingFlattenedEnvironmentPostProcessor.java
@@ -17,7 +17,7 @@
 package org.springframework.cloud.bindings.boot;
 
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.context.config.ConfigFileApplicationListener;
+import org.springframework.boot.context.config.ConfigDataEnvironmentPostProcessor;
 import org.springframework.boot.context.event.ApplicationPreparedEvent;
 import org.springframework.boot.env.EnvironmentPostProcessor;
 import org.springframework.boot.logging.DeferredLog;
@@ -58,8 +58,8 @@ public final class BindingFlattenedEnvironmentPostProcessor implements Applicati
 
     @Override
     public int getOrder() {
-        // Before ConfigFileApplicationListener so values there can use values from {@link Bindings}.
-        return ConfigFileApplicationListener.DEFAULT_ORDER - 1;
+        // Before ConfigDataEnvironmentPostProcessor so values there can use values from {@link Bindings}.
+        return ConfigDataEnvironmentPostProcessor.ORDER - 1;
     }
 
     @Override

--- a/src/main/java/org/springframework/cloud/bindings/boot/BindingSpecificEnvironmentPostProcessor.java
+++ b/src/main/java/org/springframework/cloud/bindings/boot/BindingSpecificEnvironmentPostProcessor.java
@@ -17,7 +17,7 @@
 package org.springframework.cloud.bindings.boot;
 
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.context.config.ConfigFileApplicationListener;
+import org.springframework.boot.context.config.ConfigDataEnvironmentPostProcessor;
 import org.springframework.boot.context.event.ApplicationPreparedEvent;
 import org.springframework.boot.env.EnvironmentPostProcessor;
 import org.springframework.boot.logging.DeferredLog;
@@ -76,8 +76,8 @@ public final class BindingSpecificEnvironmentPostProcessor implements Applicatio
 
     @Override
     public int getOrder() {
-        // Before ConfigFileApplicationListener so values there can use values from {@link Bindings}.
-        return ConfigFileApplicationListener.DEFAULT_ORDER - 1;
+        // Before ConfigDataEnvironmentPostProcessor so values there can use values from {@link Bindings}.
+        return ConfigDataEnvironmentPostProcessor.ORDER - 1;
     }
 
     @Override

--- a/src/main/java/org/springframework/cloud/bindings/boot/CassandraBindingsPropertiesProcessor.java
+++ b/src/main/java/org/springframework/cloud/bindings/boot/CassandraBindingsPropertiesProcessor.java
@@ -16,11 +16,11 @@
 
 package org.springframework.cloud.bindings.boot;
 
+import java.util.Map;
+
 import org.springframework.cloud.bindings.Binding;
 import org.springframework.cloud.bindings.Bindings;
 import org.springframework.core.env.Environment;
-
-import java.util.Map;
 
 import static org.springframework.cloud.bindings.boot.Guards.isTypeEnabled;
 
@@ -43,14 +43,19 @@ public final class CassandraBindingsPropertiesProcessor implements BindingsPrope
         bindings.filterBindings(TYPE).forEach(binding -> {
             MapMapper map = new MapMapper(binding.getSecret(), properties);
 
-            map.from("cluster-name").to("spring.data.cassandra.cluster-name");
-            map.from("compression").to("spring.data.cassandra.compression");
-            map.from("contact-points").to("spring.data.cassandra.contact-points");
-            map.from("keyspace-name").to("spring.data.cassandra.keyspace-name");
-            map.from("password").to("spring.data.cassandra.password");
-            map.from("port").to("spring.data.cassandra.port");
-            map.from("ssl").to("spring.data.cassandra.ssl");
-            map.from("username").to("spring.data.cassandra.username");
+            map.from("cluster-name").to("spring.cassandra.cluster-name");
+            map.from("compression").to("spring.cassandra.compression");
+            map.from("contact-points").to("spring.cassandra.contact-points");
+            map.from("keyspace-name").to("spring.cassandra.keyspace-name");
+            map.from("password").to("spring.cassandra.password");
+            map.from("port").to("spring.cassandra.port");
+            map.from("ssl").to("spring.cassandra.ssl");
+            map.from("username").to("spring.cassandra.username");
+
+            map.from("request.throttler.drain-interval").to("spring.cassandra.request.throttler.drain-interval");
+            map.from("request.throttler.max-concurrent-requests").to("spring.cassandra.request.throttler.max-concurrent-requests");
+            map.from("request.throttler.max-queue-size").to("spring.cassandra.request.throttler.max-queue-size");
+            map.from("request.throttler.max-requests-per-second").to("spring.cassandra.request.throttler.max-requests-per-second");
         });
     }
 

--- a/src/main/java/org/springframework/cloud/bindings/boot/CouchbaseBindingsPropertiesProcessor.java
+++ b/src/main/java/org/springframework/cloud/bindings/boot/CouchbaseBindingsPropertiesProcessor.java
@@ -43,11 +43,8 @@ final class CouchbaseBindingsPropertiesProcessor implements BindingsPropertiesPr
         bindings.filterBindings(TYPE).forEach(binding -> {
             MapMapper map = new MapMapper(binding.getSecret(), properties);
 
-            map.from("bootstrap-hosts").to("spring.couchbase.bootstrap-hosts");
-            map.from("bucket.name").to("spring.couchbase.bucket.name");
-            map.from("bucket.password").to("spring.couchbase.bucket.password");
-            map.from("env.bootstrap.http-direct-port").to("spring.couchbase.env.bootstrap.http-direct-port");
-            map.from("env.bootstrap.http-ssl-port").to("spring.couchbase.env.bootstrap.http-ssl-port");
+            map.from("bucket-name").to("spring.data.couchbase.bucket-name");
+            map.from("connection-string").to("spring.couchbase.connection-string");
             map.from("password").to("spring.couchbase.password");
             map.from("username").to("spring.couchbase.username");
         });

--- a/src/main/java/org/springframework/cloud/bindings/boot/ElasticsearchBindingsPropertiesProcessor.java
+++ b/src/main/java/org/springframework/cloud/bindings/boot/ElasticsearchBindingsPropertiesProcessor.java
@@ -44,17 +44,9 @@ final class ElasticsearchBindingsPropertiesProcessor implements BindingsProperti
         bindings.filterBindings(TYPE).forEach(binding -> {
             MapMapper map = new MapMapper(binding.getSecret(), properties);
 
-            map.from("endpoints").to("spring.data.elasticsearch.client.reactive.endpoints");
-            map.from("password").to("spring.data.elasticsearch.client.reactive.password");
-            map.from("use-ssl").to("spring.data.elasticsearch.client.reactive.use-ssl");
-            map.from("username").to("spring.data.elasticsearch.client.reactive.username");
-            map.from("password").to("spring.elasticsearch.jest.password");
-            map.from("proxy.host").to("spring.elasticsearch.jest.proxy.host");
-            map.from("proxy.port").to("spring.elasticsearch.jest.proxy.port");
-            map.from("username").to("spring.elasticsearch.jest.username");
-            map.from("password").to("spring.elasticsearch.rest.password");
-            map.from("uris").to("spring.elasticsearch.rest.uris");
-            map.from("username").to("spring.elasticsearch.rest.username");
+            map.from("password").to("spring.elasticsearch.password");
+            map.from("uris").to("spring.elasticsearch.uris");
+            map.from("username").to("spring.elasticsearch.username");
         });
     }
 

--- a/src/main/java/org/springframework/cloud/bindings/boot/Neo4JBindingsPropertiesProcessor.java
+++ b/src/main/java/org/springframework/cloud/bindings/boot/Neo4JBindingsPropertiesProcessor.java
@@ -42,9 +42,9 @@ final class Neo4JBindingsPropertiesProcessor implements BindingsPropertiesProces
         bindings.filterBindings(TYPE).forEach(binding -> {
             MapMapper map = new MapMapper(binding.getSecret(), properties);
 
-            map.from("password").to("spring.data.neo4j.password");
-            map.from("uri").to("spring.data.neo4j.uri");
-            map.from("username").to("spring.data.neo4j.username");
+            map.from("uri").to("spring.neo4j.uri");
+            map.from("username").to("spring.neo4j.authentication.username");
+            map.from("password").to("spring.neo4j.authentication.password");
         });
     }
 

--- a/src/main/java/org/springframework/cloud/bindings/boot/RedisBindingsPropertiesProcessor.java
+++ b/src/main/java/org/springframework/cloud/bindings/boot/RedisBindingsPropertiesProcessor.java
@@ -43,17 +43,17 @@ public final class RedisBindingsPropertiesProcessor implements BindingsPropertie
         bindings.filterBindings(TYPE).forEach(binding -> {
             MapMapper map = new MapMapper(binding.getSecret(), properties);
 
-            map.from("client-name").to("spring.redis.client-name");
-            map.from("cluster.max-redirects").to("spring.redis.cluster.max-redirects");
-            map.from("cluster.nodes").to("spring.redis.cluster.nodes");
-            map.from("database").to("spring.redis.database");
-            map.from("host").to("spring.redis.host");
-            map.from("password").to("spring.redis.password");
-            map.from("port").to("spring.redis.port");
-            map.from("sentinel.master").to("spring.redis.sentinel.master");
-            map.from("sentinel.nodes").to("spring.redis.sentinel.nodes");
-            map.from("ssl").to("spring.redis.ssl");
-            map.from("url").to("spring.redis.url");
+            map.from("client-name").to("spring.data.redis.client-name");
+            map.from("cluster.max-redirects").to("spring.data.redis.cluster.max-redirects");
+            map.from("cluster.nodes").to("spring.data.redis.cluster.nodes");
+            map.from("database").to("spring.data.redis.database");
+            map.from("host").to("spring.data.redis.host");
+            map.from("password").to("spring.data.redis.password");
+            map.from("port").to("spring.data.redis.port");
+            map.from("sentinel.master").to("spring.data.redis.sentinel.master");
+            map.from("sentinel.nodes").to("spring.data.redis.sentinel.nodes");
+            map.from("ssl").to("spring.data.redis.ssl");
+            map.from("url").to("spring.data.redis.url");
         });
     }
 

--- a/src/main/java/org/springframework/cloud/bindings/boot/VaultBindingsPropertiesProcessor.java
+++ b/src/main/java/org/springframework/cloud/bindings/boot/VaultBindingsPropertiesProcessor.java
@@ -76,16 +76,21 @@ public final class VaultBindingsPropertiesProcessor implements BindingsPropertie
                 case "AWS_IAM":
                     map.from("role").to("spring.cloud.vault.aws-iam.role");
                     map.from("aws-path").to("spring.cloud.vault.aws-iam.aws-path");
-                    map.from("aws-iam-server-id").to("spring.cloud.vault.aws-iam.server-id");
+                    map.from("aws-iam-server-name").to("spring.cloud.vault.aws-iam.server-name");
                     map.from("aws-sts-endpoint-uri").to("spring.cloud.vault.aws-iam.endpoint-uri");
                     break;
                 case "AZURE_MSI":
                     map.from("role").to("spring.cloud.vault.azure-msi.role");
                     map.from("azure-path").to("spring.cloud.vault.azure-msi.azure-path");
+                    map.from("metadata-service").to("spring.cloud.vault.azure-msi.metadata-service");
+                    map.from("identity-token-service").to("spring.cloud.vault.azure-msi.identity-token-service");
                     break;
                 case "CERT":
                     properties.put("spring.cloud.vault.ssl.key-store", binding.getSecretFilePath("keystore.jks").toString());
                     map.from("key-store-password").to("spring.cloud.vault.ssl.key-store-password");
+                    properties.put("spring.cloud.vault.ssl.trust-store", binding.getSecretFilePath("truststore.jks").toString());
+                    map.from("trust-store").to("spring.cloud.vault.ssl.trust-store");
+                    map.from("trust-store-password").to("spring.cloud.vault.ssl.trust-store-password");
                     map.from("cert-auth-path").to("spring.cloud.vault.ssl.cert-auth-path");
                     break;
                 case "GCP_GCE":
@@ -102,11 +107,12 @@ public final class VaultBindingsPropertiesProcessor implements BindingsPropertie
                     map.from("gcp-path").to("spring.cloud.vault.gcp-iam.gcp-path");
                     map.from("jwt-validity").to("spring.cloud.vault.gcp-iam.jwt-validity");
                     map.from("gcp-project-id").to("spring.cloud.vault.gcp-iam.project-id");
-                    map.from("gcp-service-account").to("spring.cloud.vault.gcp-iam.service-account");
+                    map.from("gcp-service-account").to("spring.cloud.vault.gcp-iam.service-account-id");
                     break;
                 case "KUBERNETES":
                     map.from("role").to("spring.cloud.vault.kubernetes.role");
                     map.from("kubernetes-path").to("spring.cloud.vault.kubernetes.kubernetes-path");
+                    map.from("kubernetes-service-account-token-file").to("spring.cloud.vault.kubernetes.kubernetes-service-account-token-file");
                     break;
                 default:
                     LOG.warn(String.format("Binding '%s' contains unrecognized 'method'", binding.getName()));

--- a/src/test/java/org/springframework/cloud/bindings/boot/ArtemisBindingsPropertiesProcessorTest.java
+++ b/src/test/java/org/springframework/cloud/bindings/boot/ArtemisBindingsPropertiesProcessorTest.java
@@ -37,8 +37,7 @@ final class ArtemisBindingsPropertiesProcessorTest {
                     new FluentMap()
                             .withEntry(Binding.TYPE, TYPE)
                             .withEntry("mode", "EMBEDDED")
-                            .withEntry("host", "test-host")
-                            .withEntry("port", "test-port")
+                            .withEntry("broker-url", "tcp://test-host:test-port")
                             .withEntry("user", "test-user")
                             .withEntry("password", "test-password")
             )
@@ -54,9 +53,8 @@ final class ArtemisBindingsPropertiesProcessorTest {
         new ArtemisBindingsPropertiesProcessor().process(environment, bindings, properties);
         assertThat(properties)
                 .containsEntry("spring.artemis.mode", "EMBEDDED")
-                .containsEntry("spring.artemis.host", "test-host")
+                .containsEntry("spring.artemis.broker-url", "tcp://test-host:test-port")
                 .containsEntry("spring.artemis.password", "test-password")
-                .containsEntry("spring.artemis.port", "test-port")
                 .containsEntry("spring.artemis.user", "test-user");
     }
 

--- a/src/test/java/org/springframework/cloud/bindings/boot/BindingFlattenedEnvironmentPostProcessorTest.java
+++ b/src/test/java/org/springframework/cloud/bindings/boot/BindingFlattenedEnvironmentPostProcessorTest.java
@@ -19,7 +19,7 @@ package org.springframework.cloud.bindings.boot;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.context.config.ConfigFileApplicationListener;
+import org.springframework.boot.context.config.ConfigDataEnvironmentPostProcessor;
 import org.springframework.cloud.bindings.Binding;
 import org.springframework.cloud.bindings.Bindings;
 import org.springframework.cloud.bindings.FluentMap;
@@ -82,7 +82,7 @@ final class BindingFlattenedEnvironmentPostProcessorTest {
     @DisplayName("has order before ConfigFileApplicationListener")
     void order() {
         assertThat(new BindingFlattenedEnvironmentPostProcessor(new Bindings()).getOrder())
-                .isLessThan(ConfigFileApplicationListener.DEFAULT_ORDER);
+                .isLessThan(ConfigDataEnvironmentPostProcessor.ORDER);
     }
 
 }

--- a/src/test/java/org/springframework/cloud/bindings/boot/BindingSpecificEnvironmentPostProcessorTest.java
+++ b/src/test/java/org/springframework/cloud/bindings/boot/BindingSpecificEnvironmentPostProcessorTest.java
@@ -19,7 +19,7 @@ package org.springframework.cloud.bindings.boot;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.context.config.ConfigFileApplicationListener;
+import org.springframework.boot.context.config.ConfigDataEnvironmentPostProcessor;
 import org.springframework.cloud.bindings.Binding;
 import org.springframework.cloud.bindings.Bindings;
 import org.springframework.cloud.bindings.FluentMap;
@@ -98,7 +98,7 @@ final class BindingSpecificEnvironmentPostProcessorTest {
     @DisplayName("has order before ConfigFileApplicationListener")
     void order() {
         assertThat(new BindingSpecificEnvironmentPostProcessor(new Bindings()).getOrder())
-                .isLessThan(ConfigFileApplicationListener.DEFAULT_ORDER);
+                .isLessThan(ConfigDataEnvironmentPostProcessor.ORDER);
     }
 
     @Test

--- a/src/test/java/org/springframework/cloud/bindings/boot/CassandraBindingsPropertiesProcessorTest.java
+++ b/src/test/java/org/springframework/cloud/bindings/boot/CassandraBindingsPropertiesProcessorTest.java
@@ -44,6 +44,10 @@ final class CassandraBindingsPropertiesProcessorTest {
                             .withEntry("port", "test-port")
                             .withEntry("ssl", "test-ssl")
                             .withEntry("username", "test-username")
+                            .withEntry("request.throttler.drain-interval", "test-drain-interval")
+                            .withEntry("request.throttler.max-concurrent-requests", "test-max-concurrent-requests")
+                            .withEntry("request.throttler.max-queue-size", "test-max-queue-size")
+                            .withEntry("request.throttler.max-requests-per-second", "test-max-requests-per-second")
             )
     );
 
@@ -56,14 +60,18 @@ final class CassandraBindingsPropertiesProcessorTest {
     void test() {
         new CassandraBindingsPropertiesProcessor().process(environment, bindings, properties);
         assertThat(properties)
-                .containsEntry("spring.data.cassandra.cluster-name", "test-cluster-name")
-                .containsEntry("spring.data.cassandra.compression", "test-compression")
-                .containsEntry("spring.data.cassandra.contact-points", "test-contact-points")
-                .containsEntry("spring.data.cassandra.keyspace-name", "test-keyspace-name")
-                .containsEntry("spring.data.cassandra.password", "test-password")
-                .containsEntry("spring.data.cassandra.port", "test-port")
-                .containsEntry("spring.data.cassandra.ssl", "test-ssl")
-                .containsEntry("spring.data.cassandra.username", "test-username");
+                .containsEntry("spring.cassandra.cluster-name", "test-cluster-name")
+                .containsEntry("spring.cassandra.compression", "test-compression")
+                .containsEntry("spring.cassandra.contact-points", "test-contact-points")
+                .containsEntry("spring.cassandra.keyspace-name", "test-keyspace-name")
+                .containsEntry("spring.cassandra.password", "test-password")
+                .containsEntry("spring.cassandra.port", "test-port")
+                .containsEntry("spring.cassandra.ssl", "test-ssl")
+                .containsEntry("spring.cassandra.username", "test-username")
+                .containsEntry("spring.cassandra.request.throttler.drain-interval", "test-drain-interval")
+                .containsEntry("spring.cassandra.request.throttler.max-concurrent-requests", "test-max-concurrent-requests")
+                .containsEntry("spring.cassandra.request.throttler.max-queue-size", "test-max-queue-size")
+                .containsEntry("spring.cassandra.request.throttler.max-requests-per-second", "test-max-requests-per-second");
     }
 
     @Test

--- a/src/test/java/org/springframework/cloud/bindings/boot/CouchbaseBindingsPropertiesProcessorTest.java
+++ b/src/test/java/org/springframework/cloud/bindings/boot/CouchbaseBindingsPropertiesProcessorTest.java
@@ -36,13 +36,10 @@ final class CouchbaseBindingsPropertiesProcessorTest {
             new Binding("test-name", Paths.get("test-path"),
                     new FluentMap()
                             .withEntry(Binding.TYPE, TYPE)
-                            .withEntry("bootstrap-hosts", "test-bootstrap-hosts")
-                            .withEntry("bucket.name", "test-bucket-name")
-                            .withEntry("bucket.password", "test-bucket-password")
-                            .withEntry("env.bootstrap.http-direct-port", "test-env-bootstrap-http-direct-port")
-                            .withEntry("env.bootstrap.http-ssl-port", "test-env-bootstrap-http-ssl-port")
-                            .withEntry("password", "test-password")
+                            .withEntry("connection-string", "test-connection-string")
+                            .withEntry("bucket-name", "test-bucket-name")
                             .withEntry("username", "test-username")
+                            .withEntry("password", "test-password")
             )
     );
 
@@ -55,13 +52,10 @@ final class CouchbaseBindingsPropertiesProcessorTest {
     void test() {
         new CouchbaseBindingsPropertiesProcessor().process(environment, bindings, properties);
         assertThat(properties)
-                .containsEntry("spring.couchbase.bootstrap-hosts", "test-bootstrap-hosts")
-                .containsEntry("spring.couchbase.bucket.name", "test-bucket-name")
-                .containsEntry("spring.couchbase.bucket.password", "test-bucket-password")
-                .containsEntry("spring.couchbase.env.bootstrap.http-direct-port", "test-env-bootstrap-http-direct-port")
-                .containsEntry("spring.couchbase.env.bootstrap.http-ssl-port", "test-env-bootstrap-http-ssl-port")
-                .containsEntry("spring.couchbase.password", "test-password")
-                .containsEntry("spring.couchbase.username", "test-username");
+                .containsEntry("spring.couchbase.connection-string", "test-connection-string")
+                .containsEntry("spring.data.couchbase.bucket-name", "test-bucket-name")
+                .containsEntry("spring.couchbase.username", "test-username")
+                .containsEntry("spring.couchbase.password", "test-password");
     }
 
     @Test

--- a/src/test/java/org/springframework/cloud/bindings/boot/ElasticsearchBindingsPropertiesProcessorTest.java
+++ b/src/test/java/org/springframework/cloud/bindings/boot/ElasticsearchBindingsPropertiesProcessorTest.java
@@ -36,13 +36,9 @@ final class ElasticsearchBindingsPropertiesProcessorTest {
             new Binding("test-name", Paths.get("test-path"),
                     new FluentMap()
                             .withEntry(Binding.TYPE, TYPE)
-                            .withEntry("endpoints", "test-endpoints")
                             .withEntry("password", "test-password")
-                            .withEntry("use-ssl", "test-use-ssl")
-                            .withEntry("username", "test-username")
-                            .withEntry("proxy.host", "test-proxy-host")
-                            .withEntry("proxy.port", "test-proxy-port")
                             .withEntry("uris", "test-uris")
+                            .withEntry("username", "test-username")
             )
     );
 
@@ -55,17 +51,9 @@ final class ElasticsearchBindingsPropertiesProcessorTest {
     void test() {
         new ElasticsearchBindingsPropertiesProcessor().process(environment, bindings, properties);
         assertThat(properties)
-                .containsEntry("spring.data.elasticsearch.client.reactive.endpoints", "test-endpoints")
-                .containsEntry("spring.data.elasticsearch.client.reactive.password", "test-password")
-                .containsEntry("spring.data.elasticsearch.client.reactive.use-ssl", "test-use-ssl")
-                .containsEntry("spring.data.elasticsearch.client.reactive.username", "test-username")
-                .containsEntry("spring.elasticsearch.jest.password", "test-password")
-                .containsEntry("spring.elasticsearch.jest.proxy.host", "test-proxy-host")
-                .containsEntry("spring.elasticsearch.jest.proxy.port", "test-proxy-port")
-                .containsEntry("spring.elasticsearch.jest.username", "test-username")
-                .containsEntry("spring.elasticsearch.rest.password", "test-password")
-                .containsEntry("spring.elasticsearch.rest.uris", "test-uris")
-                .containsEntry("spring.elasticsearch.rest.username", "test-username");
+                .containsEntry("spring.elasticsearch.password", "test-password")
+                .containsEntry("spring.elasticsearch.uris", "test-uris")
+                .containsEntry("spring.elasticsearch.username", "test-username");
     }
 
     @Test

--- a/src/test/java/org/springframework/cloud/bindings/boot/Neo4JBindingsPropertiesProcessorTest.java
+++ b/src/test/java/org/springframework/cloud/bindings/boot/Neo4JBindingsPropertiesProcessorTest.java
@@ -36,9 +36,9 @@ final class Neo4JBindingsPropertiesProcessorTest {
             new Binding("test-name", Paths.get("test-path"),
                     new FluentMap()
                             .withEntry(Binding.TYPE, TYPE)
-                            .withEntry("password", "test-password")
                             .withEntry("uri", "test-uri")
                             .withEntry("username", "test-username")
+                            .withEntry("password", "test-password")
             )
     );
 
@@ -51,9 +51,9 @@ final class Neo4JBindingsPropertiesProcessorTest {
     void test() {
         new Neo4JBindingsPropertiesProcessor().process(environment, bindings, properties);
         assertThat(properties)
-                .containsEntry("spring.data.neo4j.password", "test-password")
-                .containsEntry("spring.data.neo4j.uri", "test-uri")
-                .containsEntry("spring.data.neo4j.username", "test-username");
+                .containsEntry("spring.neo4j.uri", "test-uri")
+                .containsEntry("spring.neo4j.authentication.username", "test-username")
+                .containsEntry("spring.neo4j.authentication.password", "test-password");
     }
 
     @Test

--- a/src/test/java/org/springframework/cloud/bindings/boot/RedisBindingsPropertiesProcessorTest.java
+++ b/src/test/java/org/springframework/cloud/bindings/boot/RedisBindingsPropertiesProcessorTest.java
@@ -59,17 +59,17 @@ final class RedisBindingsPropertiesProcessorTest {
     void test() {
         new RedisBindingsPropertiesProcessor().process(environment, bindings, properties);
         assertThat(properties)
-                .containsEntry("spring.redis.client-name", "test-client-name")
-                .containsEntry("spring.redis.cluster.max-redirects", "test-cluster-max-redirects")
-                .containsEntry("spring.redis.cluster.nodes", "test-cluster-nodes")
-                .containsEntry("spring.redis.database", "test-database")
-                .containsEntry("spring.redis.host", "test-host")
-                .containsEntry("spring.redis.password", "test-password")
-                .containsEntry("spring.redis.port", "test-port")
-                .containsEntry("spring.redis.sentinel.master", "test-sentinel-master")
-                .containsEntry("spring.redis.sentinel.nodes", "test-sentinel-nodes")
-                .containsEntry("spring.redis.ssl", "test-ssl")
-                .containsEntry("spring.redis.url", "test-url");
+                .containsEntry("spring.data.redis.client-name", "test-client-name")
+                .containsEntry("spring.data.redis.cluster.max-redirects", "test-cluster-max-redirects")
+                .containsEntry("spring.data.redis.cluster.nodes", "test-cluster-nodes")
+                .containsEntry("spring.data.redis.database", "test-database")
+                .containsEntry("spring.data.redis.host", "test-host")
+                .containsEntry("spring.data.redis.password", "test-password")
+                .containsEntry("spring.data.redis.port", "test-port")
+                .containsEntry("spring.data.redis.sentinel.master", "test-sentinel-master")
+                .containsEntry("spring.data.redis.sentinel.nodes", "test-sentinel-nodes")
+                .containsEntry("spring.data.redis.ssl", "test-ssl")
+                .containsEntry("spring.data.redis.url", "test-url");
     }
 
     @Test

--- a/src/test/java/org/springframework/cloud/bindings/boot/VaultBindingsPropertiesProcessorTest.java
+++ b/src/test/java/org/springframework/cloud/bindings/boot/VaultBindingsPropertiesProcessorTest.java
@@ -107,8 +107,10 @@ final class VaultBindingsPropertiesProcessorTest {
                         baseSecret()
                                 .withEntry("authentication-method", "cert")
                                 .withEntry("cert-auth-path", "test-cert-auth-path")
-                                .withEntry("key-store-password", "test-key-store-password")
                                 .withEntry("keystore.jks", "key store contents!")
+                                .withEntry("key-store-password", "test-key-store-password")
+                                .withEntry("truststore.jks", "trust store contents!")
+                                .withEntry("trust-store-password", "test-trust-store-password")
                 )
         );
 
@@ -117,9 +119,11 @@ final class VaultBindingsPropertiesProcessorTest {
                 .containsEntry("spring.cloud.vault.uri", "test-uri")
                 .containsEntry("spring.cloud.vault.namespace", "test-namespace")
                 .containsEntry("spring.cloud.vault.authentication", "cert")
+                .containsEntry("spring.cloud.vault.ssl.cert-auth-path", "test-cert-auth-path")
                 .containsEntry("spring.cloud.vault.ssl.key-store", "test-path/keystore.jks")
                 .containsEntry("spring.cloud.vault.ssl.key-store-password", "test-key-store-password")
-                .containsEntry("spring.cloud.vault.ssl.cert-auth-path", "test-cert-auth-path");
+                .containsEntry("spring.cloud.vault.ssl.trust-store", "test-path/truststore.jks")
+                .containsEntry("spring.cloud.vault.ssl.trust-store-password", "test-trust-store-password");
     }
 
     @Test
@@ -154,7 +158,7 @@ final class VaultBindingsPropertiesProcessorTest {
                 new Binding("test-name", Paths.get("test-path"),
                         baseSecret()
                                 .withEntry("authentication-method", "aws_iam")
-                                .withEntry("aws-iam-server-id", "test-server-id")
+                                .withEntry("aws-iam-server-name", "test-server-name")
                                 .withEntry("aws-path", "test-aws-path")
                                 .withEntry("aws-sts-endpoint-uri", "test-endpoint-uri")
                                 .withEntry("role", "test-role")
@@ -168,7 +172,7 @@ final class VaultBindingsPropertiesProcessorTest {
                 .containsEntry("spring.cloud.vault.authentication", "aws_iam")
                 .containsEntry("spring.cloud.vault.aws-iam.role", "test-role")
                 .containsEntry("spring.cloud.vault.aws-iam.aws-path", "test-aws-path")
-                .containsEntry("spring.cloud.vault.aws-iam.server-id", "test-server-id")
+                .containsEntry("spring.cloud.vault.aws-iam.server-name", "test-server-name")
                 .containsEntry("spring.cloud.vault.aws-iam.endpoint-uri", "test-endpoint-uri");
     }
 
@@ -181,6 +185,8 @@ final class VaultBindingsPropertiesProcessorTest {
                                 .withEntry("authentication-method", "azure_msi")
                                 .withEntry("azure-path", "test-azure-path")
                                 .withEntry("role", "test-role")
+                                .withEntry("metadata-service", "test-metadata-service")
+                                .withEntry("identity-token-service", "test-identity-token-service")
                 )
         );
 
@@ -190,7 +196,9 @@ final class VaultBindingsPropertiesProcessorTest {
                 .containsEntry("spring.cloud.vault.namespace", "test-namespace")
                 .containsEntry("spring.cloud.vault.authentication", "azure_msi")
                 .containsEntry("spring.cloud.vault.azure-msi.role", "test-role")
-                .containsEntry("spring.cloud.vault.azure-msi.azure-path", "test-azure-path");
+                .containsEntry("spring.cloud.vault.azure-msi.azure-path", "test-azure-path")
+                .containsEntry("spring.cloud.vault.azure-msi.metadata-service", "test-metadata-service")
+                .containsEntry("spring.cloud.vault.azure-msi.identity-token-service", "test-identity-token-service");
     }
 
     @Test
@@ -244,7 +252,7 @@ final class VaultBindingsPropertiesProcessorTest {
                 .containsEntry("spring.cloud.vault.gcp-iam.gcp-path", "test-gcp-path")
                 .containsEntry("spring.cloud.vault.gcp-iam.jwt-validity", "test-jwt-validity")
                 .containsEntry("spring.cloud.vault.gcp-iam.project-id", "test-project-id")
-                .containsEntry("spring.cloud.vault.gcp-iam.service-account", "test-service-account");
+                .containsEntry("spring.cloud.vault.gcp-iam.service-account-id", "test-service-account");
     }
 
     @Test
@@ -256,6 +264,7 @@ final class VaultBindingsPropertiesProcessorTest {
                                 .withEntry("authentication-method", "kubernetes")
                                 .withEntry("role", "test-role")
                                 .withEntry("kubernetes-path", "test-kubernetes-path")
+                                .withEntry("kubernetes-service-account-token-file", "test-kubernetes-service-account-token-file")
                 )
         );
 
@@ -265,7 +274,8 @@ final class VaultBindingsPropertiesProcessorTest {
                 .containsEntry("spring.cloud.vault.namespace", "test-namespace")
                 .containsEntry("spring.cloud.vault.authentication", "kubernetes")
                 .containsEntry("spring.cloud.vault.kubernetes.role", "test-role")
-                .containsEntry("spring.cloud.vault.kubernetes.kubernetes-path", "test-kubernetes-path");
+                .containsEntry("spring.cloud.vault.kubernetes.kubernetes-path", "test-kubernetes-path")
+                .containsEntry("spring.cloud.vault.kubernetes.kubernetes-service-account-token-file", "test-kubernetes-service-account-token-file");
     }
 
     @Test
@@ -312,6 +322,8 @@ final class VaultBindingsPropertiesProcessorTest {
                                 .withEntry("cert-auth-path", "test-cert-auth-path")
                                 .withEntry("key-store-password", "test-key-store-password")
                                 .withEntry("keystore.jks", "key store contents!")
+                                .withEntry("trust-store-password", "test-key-store-password")
+                                .withEntry("truststore.jks", "trust store contents!")
                 )
         );
 


### PR DESCRIPTION
Overall, looked into the docs and code of the different projects to find config changes and fix them. On those I am more familiar with I went deeper and added some extra new properties, but for those I am not familiar I did minimal changes.

On top of the changes, one doubt I found is about Eureka, the onyl reference I found is in java-cfenv https://github.com/pivotal-cf/java-cfenv/commit/738960b4224d59818faa1fab95ce10f5c8cb2e2d, but nothing in the repo https://github.com/spring-cloud/spring-cloud-netflix. Is this really a thing or something that was added and is now not supported?


* Bump Maven plugins
* Bump Java version to 17
* Deprecations
    * Replaced ConfigFileApplicationListener.DEFAULT_ORDER by ConfigDataEnvironmentPostProcessor.ORDER which have the same value (https://docs.spring.io/spring-boot/docs/2.4.13/api/deprecated-list.html)

* Artemis
    * Updated 'host' to 'broker-url'
    * Fixed some rabbitmq properties in ArtemisBindingsPropertiesProcessor

* Cassandra
    * Fixed configuration properties: see https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#cassandra-properties
    * Added 'throttler' properties: see https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.5-Release-Notes#cassandra-throttling-properties

* Couchbase
    * Updated based on https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html#appendix.application-properties.data and https://github.com/spring-projects/spring-boot/commit/abe43b2e83713591bc23821add3763cc2c41e3bd

* Elastic
    * Based on docs, clients have been consolidated, so most properties have been removed.
    * Updated based on https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.6-Release-Notes#elasticsearch-property-consolidation

* Neo4j
    * Updated properties prefix: https://github.com/spring-projects/spring-data-neo4j/blob/main/src/main/asciidoc/appendix/migrating.adoc

* Redis
    * Updated properties prefix: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#redis-properties

* Vault, matched properties with https://github.com/spring-cloud/spring-cloud-vault/blob/main/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultProperties.java
    * NOTE: 'spring.cloud.vault.aws-iam.server-id' seems it never existed, it was alwasy serverName
        and https://github.com/spring-cloud/spring-cloud-vault/commit/9cff9eb9edadca82750c5600b0e5fcf1648492bb
    * Added new metadata-service and identity-token-service properties for AZURE_MSI
    * Added 'trust-store' configuration for CERT.
    * Ignored 'key-store-type' & 'trust-store-type' for simplicity. Current approach implies users need to convert to JKS.
    * Fixed 'gcp-service-account'
    * Added K8s token-file