### PR TITLE
javadoc bug workaround

### DIFF
--- a/src/main/java/org/springframework/cloud/bindings/package-info.java
+++ b/src/main/java/org/springframework/cloud/bindings/package-info.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-@NonNullApi
+/** */ @NonNullApi
 package org.springframework.cloud.bindings;
 
 import org.springframework.lang.NonNullApi;


### PR DESCRIPTION
package-info file detected as static file and annotation not recognised - should be fixed in Java 11.18