### PR TITLE
Fix release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.springframework.cloud</groupId>
     <artifactId>spring-cloud-bindings-parent</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Spring Cloud Cloud Native Buildpacks Bindings Parent</name>

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -29,6 +29,6 @@ EOF
 
 REPOSITORY="${PWD}"/repository
 
-cd source
+cd source/spring-cloud-bindings
 
-./mvnw deploy -Dmaven.test.skip=true -DaltDeploymentRepository="local::default::file://${REPOSITORY}"
+../mvnw deploy -Dmaven.test.skip=true -DaltDeploymentRepository="local::default::file://${REPOSITORY}"

--- a/scripts/promote-to-maven-central.sh
+++ b/scripts/promote-to-maven-central.sh
@@ -4,6 +4,6 @@ set -euo pipefail
 
 export BUILD_INFO_LOCATION=$(pwd)/repository/build-info.json
 
-java -jar /opt/concourse-release-scripts.jar publishToCentral 'RELEASE' "$BUILD_INFO_LOCATION" repository
+java -jar /concourse-release-scripts.jar publishToCentral 'RELEASE' "$BUILD_INFO_LOCATION" repository
 
 echo "Sync complete"

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -10,6 +10,9 @@ cd source
 VERSION=$(./mvnw --quiet help:evaluate -DforceStdout -Dexpression=project.version)
 
 git add pom.xml
+git add spring-cloud-bindings/pom.xml
+git add spring-cloud-bindings-tests/pom.xml
+
 git checkout -- .
 
 git \


### PR DESCRIPTION
Most release problems are solved with this PR.

Except that I got, during maven central release, this:

```
[17:35:02](XXX/spring-cloud-bindings/jobs/maven-central-main/builds/3#L64b79706:40)
2023-07-20 21:35:02.543  INFO 15 --- [           main] i.s.c.r.sonatype.SonatypeService         : Deploy complete. Closing staging repository
[17:35:02](XXX/spring-cloud-bindings/jobs/maven-central-main/builds/3#L64b79706:41)
2023-07-20 21:35:02.872  INFO 15 --- [           main] i.s.c.r.sonatype.SonatypeService         : Close requested. Awaiting result
[17:35:33](XXX/pipelines/spring-cloud-bindings/jobs/maven-central-main/builds/3#L64b79706:42)
2023-07-20 21:35:33.778 ERROR 15 --- [           main] i.s.c.r.sonatype.SonatypeService         : Close failed:
[17:35:33](XXX/spring-cloud-bindings/jobs/maven-central-main/builds/3#L64b79706:43)
    Missing Signature: '/org/springframework/cloud/spring-cloud-bindings-tests/2.0.0/spring-cloud-bindings-tests-2.0.0.jar.asc' does not exist for 'spring-cloud-bindings-tests-2.0.0.jar'.
[17:35:33](XXX/spring-cloud-bindings/jobs/maven-central-main/builds/3#L64b79706:44)
    Missing Signature: '/org/springframework/cloud/spring-cloud-bindings-tests/2.0.0/spring-cloud-bindings-tests-2.0.0.pom.asc' does not exist for 'spring-cloud-bindings-tests-2.0.0.pom'.
[17:35:33](XXX/spring-cloud-bindings/jobs/maven-central-main/builds/3#L64b79706:45)
    Missing Signature: '/org/springframework/cloud/spring-cloud-bindings-parent/2.0.0/spring-cloud-bindings-parent-2.0.0.pom.asc' does not exist for 'spring-cloud-bindings-parent-2.0.0.pom'.
```