### PR TITLE
oauth2 processor: make client-authentication-method compatible with Boot 2.5

### DIFF
--- a/spring-cloud-bindings/src/test/java/org/springframework/cloud/bindings/boot/SpringSecurityOAuth2BindingsPropertiesProcessorTest.java
+++ b/spring-cloud-bindings/src/test/java/org/springframework/cloud/bindings/boot/SpringSecurityOAuth2BindingsPropertiesProcessorTest.java
@@ -210,6 +210,30 @@ final class SpringSecurityOAuth2BindingsPropertiesProcessorTest {
     }
 
     @Test
+    @DisplayName("uses Spring-Security 5.4-compatible ClientAuthenticationMethod")
+    void backwardsCompatibleClientAuthenticationMethod() {
+        Bindings clientSecretBasic = new Bindings(new Binding("binding-name", Paths.get("test-path"),
+                new FluentMap()
+                        .withEntry(Binding.TYPE, TYPE)
+                        .withEntry("provider", "some-provider")
+                        .withEntry("client-authentication-method", "client_secret_basic")
+        ));
+        new SpringSecurityOAuth2BindingsPropertiesProcessor().process(new MockEnvironment(), clientSecretBasic, properties);
+        assertThat(properties)
+                .containsEntry("spring.security.oauth2.client.registration.binding-name.client-authentication-method", "basic");
+
+        Bindings clientSecretPost = new Bindings(new Binding("binding-name", Paths.get("test-path"),
+                new FluentMap()
+                        .withEntry(Binding.TYPE, TYPE)
+                        .withEntry("provider", "some-provider")
+                        .withEntry("client-authentication-method", "client_secret_post")
+        ));
+        new SpringSecurityOAuth2BindingsPropertiesProcessor().process(new MockEnvironment(), clientSecretPost, properties);
+        assertThat(properties)
+                .containsEntry("spring.security.oauth2.client.registration.binding-name.client-authentication-method", "post");
+    }
+
+    @Test
     @DisplayName("can be disabled")
     void disabled() {
         environment.setProperty("org.springframework.cloud.bindings.boot.oauth2.enable", "false");


### PR DESCRIPTION
When consuming a Boot 3 compatible binding, we get an OAuth2 `client-authentication-method: client_secret_basic` or `client_secret_post`. But that value is not recognized by Spring Security < 5.5 (Boot < 2.5), causing very hard to debug issues at runtime (calls to the token endpoint fail because the authentication method is unknown).

This PR transforms Boot 3-compatible client-authentication-method into Boot 2.x-compatible ones, which work with all minors.