### PR TITLE
Update Wavefront property names

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,8 +450,8 @@ Disable Property: `org.springframework.cloud.bindings.boot.wavefront.enable`
 
 | Property                                        | Value         |
 | ----------------------------------------------- | ------------- |
-| `management.metrics.export.wavefront.api-token` | `{api-token}` |
-| `management.metrics.export.wavefront.uri`       | `{uri}`       |
+| `management.wavefront.api-token` | `{api-token}` |
+| `management.wavefront.uri`       | `{uri}`       |
 
 
 ## Extending Spring Boot Configuration

--- a/spring-cloud-bindings/src/main/java/org/springframework/cloud/bindings/boot/WavefrontBindingsPropertiesProcessor.java
+++ b/spring-cloud-bindings/src/main/java/org/springframework/cloud/bindings/boot/WavefrontBindingsPropertiesProcessor.java
@@ -42,8 +42,8 @@ public final class WavefrontBindingsPropertiesProcessor implements BindingsPrope
 
         bindings.filterBindings(TYPE).forEach(binding -> {
             MapMapper map = new MapMapper(binding.getSecret(), properties);
-            map.from("api-token").to("management.metrics.export.wavefront.api-token");
-            map.from("uri").to("management.metrics.export.wavefront.uri");
+            map.from("api-token").to("management.wavefront.api-token");
+            map.from("uri").to("management.wavefront.uri");
         });
     }
 

--- a/spring-cloud-bindings/src/test/java/org/springframework/cloud/bindings/boot/WavefrontBindingsPropertiesProcessorTest.java
+++ b/spring-cloud-bindings/src/test/java/org/springframework/cloud/bindings/boot/WavefrontBindingsPropertiesProcessorTest.java
@@ -50,8 +50,8 @@ final class WavefrontBindingsPropertiesProcessorTest {
     void test() {
         new WavefrontBindingsPropertiesProcessor().process(environment, bindings, properties);
         assertThat(properties)
-                .containsEntry("management.metrics.export.wavefront.api-token", "test-api-token")
-                .containsEntry("management.metrics.export.wavefront.uri", "test-uri");
+                .containsEntry("management.wavefront.api-token", "test-api-token")
+                .containsEntry("management.wavefront.uri", "test-uri");
     }
 
     @Test


### PR DESCRIPTION
Wavefront property names have changed since Spring Boot 3.0
https://docs.spring.io/spring-boot/docs/3.0.0/reference/html/actuator.html#actuator.metrics.export.wavefront

fixes https://github.com/spring-cloud/spring-cloud-bindings/issues/97