### PR TITLE
Supports mTLS for config-server clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,12 +273,21 @@ Disable Property: `org.springframework.cloud.bindings.boot.hana.enable`
 Type: `config`
 Disable Property: `org.springframework.cloud.bindings.boot.config.enable`
 
-| Property                                           | Value                |
-| -------------------------------------------------- | -------------------- |
-| `spring.cloud.config.uri`                          | `{uri}`              |
-| `spring.cloud.config.client.oauth2.clientId`       | `{client-id}`        |
-| `spring.cloud.config.client.oauth2.clientSecret`   | `{client-secret}`    |
-| `spring.cloud.config.client.oauth2.accessTokenUri` | `{access-token-uri}` |
+| Property                                             | Value                                                  |
+|------------------------------------------------------|--------------------------------------------------------|
+| `spring.cloud.config.uri`                            | `{uri}`                                                |
+| `spring.cloud.config.client.oauth2.clientId`         | `{client-id}`                                          |
+| `spring.cloud.config.client.oauth2.clientSecret`     | `{client-secret}`                                      |
+| `spring.cloud.config.client.oauth2.accessTokenUri`   | `{access-token-uri}`                                   |
+| `spring.cloud.config.tls.enabled`                    | `true` when `{tls.crt}` and `{tls.key}` are set        |
+| `spring.cloud.config.tls.key-store`                  | derived from `{tls.crt}` and `{tls.key}`               |
+| `spring.cloud.config.tls.key-store-type`             | `"PKCS12"` when `{tls.crt}` and `{tls.key}` are set    |
+| `spring.cloud.config.tls.key-store-password`         | random string when `{tls.crt}` and `{tls.key}` are set |
+| `spring.cloud.config.tls.key-alias`                  | `"config"` when `{tls.crt}` and `{tls.key}` are set    |
+| `spring.cloud.config.tls.key-password`               | `""` when `{tls.crt}` and `{tls.key}` are set          |
+| `spring.cloud.config.tls.trust-store`                | derived from `{ca.crt}` when it is set                 |
+| `spring.cloud.config.tls.trust-store-type`           | `"PKCS12"` when `{ca.crt}` is set                      |
+| `spring.cloud.config.tls.trust-store-password`       | random string when `{ca.crt}` is set                   |
 
 ## SCS Eureka
 

--- a/spring-cloud-bindings/src/main/java/org/springframework/cloud/bindings/boot/ConfigServerBindingsPropertiesProcessor.java
+++ b/spring-cloud-bindings/src/main/java/org/springframework/cloud/bindings/boot/ConfigServerBindingsPropertiesProcessor.java
@@ -18,9 +18,19 @@ package org.springframework.cloud.bindings.boot;
 
 import org.springframework.cloud.bindings.Binding;
 import org.springframework.cloud.bindings.Bindings;
+import org.springframework.cloud.bindings.boot.pem.PemSslStoreHelper;
 import org.springframework.core.env.Environment;
+import org.springframework.util.StringUtils;
 
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
 import java.util.Map;
+import java.util.Random;
 
 import static org.springframework.cloud.bindings.boot.Guards.isTypeEnabled;
 
@@ -40,12 +50,63 @@ final class ConfigServerBindingsPropertiesProcessor implements BindingsPropertie
         }
 
         bindings.filterBindings(TYPE).forEach(binding -> {
-            MapMapper map = new MapMapper(binding.getSecret(), properties);
+            Map<String, String> secret = binding.getSecret();
+            MapMapper map = new MapMapper(secret, properties);
             map.from("uri").to("spring.cloud.config.uri");
             map.from("client-id").to("spring.cloud.config.client.oauth2.clientId");
             map.from("client-secret").to("spring.cloud.config.client.oauth2.clientSecret");
             map.from("access-token-uri").to("spring.cloud.config.client.oauth2.accessTokenUri");
-        });
 
+            // When tls.crt and tls.key are set, enable mTLS for config client.
+            String clientKey = secret.get("tls.key");
+            String clientCert = secret.get("tls.crt");
+            if (StringUtils.hasText(clientCert) != StringUtils.hasText(clientKey)) {
+                throw new IllegalArgumentException("binding secret error: tls.key and tls.crt must both be set if either is set");
+            }
+
+            if (clientKey != null && !clientKey.isEmpty()) {
+                String generatedPassword = new Random().ints(97 /* letter a */, 122 /* letter z */ + 1)
+                        .limit(10)
+                        .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                        .toString();
+
+                // Create a keystore
+                String keyFilePath = createStore("client-keystore", generatedPassword, clientCert, clientKey, "config");
+
+                properties.put("spring.cloud.config.tls.enabled", true);
+                properties.put("spring.cloud.config.tls.key-alias", "config");
+                properties.put("spring.cloud.config.tls.key-store", "file:" + keyFilePath);
+                properties.put("spring.cloud.config.tls.key-store-type", "PKCS12");
+                properties.put("spring.cloud.config.tls.key-store-password", generatedPassword);
+                properties.put("spring.cloud.config.tls.key-password", "");
+
+                String caCert = secret.get("ca.crt");
+                if (caCert != null && !caCert.isEmpty()) {
+                    // Create a truststore from the CA cert
+                    String trustFilePath = createStore("client-truststore", generatedPassword, caCert, null, "ca");
+                    properties.put("spring.cloud.config.tls.trust-store", "file:" + trustFilePath);
+                    properties.put("spring.cloud.config.tls.trust-store-type", "PKCS12");
+                    properties.put("spring.cloud.config.tls.trust-store-password", generatedPassword);
+                }
+            }
+        });
+    }
+
+    private static String createStore(String name, String password, String certificate, String privateKey, String keyAlias) {
+        String path = Paths.get(System.getProperty("java.io.tmpdir"), name + ".p12").toString();
+        KeyStore store = PemSslStoreHelper.createKeyStore("key", "PKCS12", certificate, privateKey, keyAlias);
+
+        try (FileOutputStream fos = new FileOutputStream(path)) {
+            store.store(fos, password.toCharArray());
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException("Unable to write " + name, e);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("Cryptographic algorithm not available", e);
+        } catch (CertificateException e) {
+            throw new IllegalStateException("Unable to process certificate", e);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to create " + name, e);
+        }
+        return path;
     }
 }


### PR DESCRIPTION
This PR configures the TLS for the config-server clients, when `tls.key`, `tls.crt` and optionally `ca.crt` are available in bindings. 